### PR TITLE
instant_answer: Fix place id getter on single result from an intention

### DIFF
--- a/idunn/api/instant_answer.py
+++ b/idunn/api/instant_answer.py
@@ -116,7 +116,7 @@ async def get_instant_answer(
         raise HTTPException(404)
 
     if len(places) == 1:
-        place_id = places[0]["id"]
+        place_id = places[0].id
         return InstantAnswerResponse(
             places=places,
             source=places_bbox_response.source,

--- a/tests/fixtures/autocomplete/__init__.py
+++ b/tests/fixtures/autocomplete/__init__.py
@@ -83,8 +83,11 @@ def mock_autocomplete_unavailable(httpx_mock):
 
 
 @pytest.fixture
-def mock_bragi_carrefour_in_bbox(httpx_mock):
+def mock_bragi_carrefour_in_bbox(request, httpx_mock):
     bragi_response = read_fixture("fixtures/autocomplete/carrefour_in_bbox.json")
+    limit = getattr(request, "param", {}).get("limit")
+    if limit is not None:
+        bragi_response["features"] = bragi_response["features"][:limit]
     with override_settings({"BRAGI_BASE_URL": BASE_URL}):
         httpx_mock.post(re.compile(f"^{BASE_URL}/autocomplete"), content=bragi_response)
         yield

--- a/tests/test_instant_answer.py
+++ b/tests/test_instant_answer.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi.testclient import TestClient
 from app import app
 
@@ -27,5 +28,18 @@ def test_ia_intention_full_text(
     assert response.status_code == 200
     response_json = response.json()
     assert len(response_json["places"]) == 5
+    place = response_json["places"][0]
+    assert place["name"] == "Carrefour Market"
+
+
+@pytest.mark.parametrize("mock_bragi_carrefour_in_bbox", [{"limit": 1}], indirect=True)
+def test_ia_intention_single_result(
+    mock_NLU_with_brand_and_city, mock_autocomplete_get, mock_bragi_carrefour_in_bbox
+):
+    client = TestClient(app)
+    response = client.get("/v1/instant_answer", params={"q": "carrefour à paris", "lang": "fr"})
+    assert response.status_code == 200
+    response_json = response.json()
+    assert len(response_json["places"]) == 1
     place = response_json["places"][0]
     assert place["name"] == "Carrefour Market"


### PR DESCRIPTION
Fixes an oversight in #180  
Places returned by `get_places_bbox` are instances of `Place` model , and its properties should be accessed via attritbutes.