### PR TITLE
optim: Return ORJSONResponse directly for instant_answer

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -46,6 +46,7 @@ httpx = ">=0.12.0"
 geopy = "*"
 py-mini-racer = "*"
 geojson-pydantic = "*"
+orjson = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "21aa8481bd9cd1e43f33cf25051a15e1cec099a5b724252df8074c05980da3ce"
+            "sha256": "ff26f629a8ba907e08845a82af40181c7e0d10de9741bf5a7601c686786d229c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -144,6 +144,31 @@
                 "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
             "version": "==2.10"
+        },
+        "orjson": {
+            "hashes": [
+                "sha256:0024778b60e7069efc6e6a2eee54e1f699215b79e1b7011a18019009bcca353d",
+                "sha256:133e076b13aa448f45083ddda1871952abb9a8618e06001b3e2add4e7f260257",
+                "sha256:15951fd99ec4bc975e27c9fcffe42a2bce72fc31d3cd435cf704fbcdee5aa016",
+                "sha256:27a609233c3152e6df22b896be978de27e59ea589f5485c66cdd4279c4c58e09",
+                "sha256:47fafdb5117c06c005e71822be8ab26fae637b0a7acab557c3066fa028660d3e",
+                "sha256:5756c00100034c344bb45243584cffa34811b3b90644f15fa1515e6371849ae8",
+                "sha256:69c19a957dbfa72e90f067101564be1a46cf30d1a0c142f78d140cc7261e3d52",
+                "sha256:6ba90cc0921367316221979025a08186de9987b2f2307a86d356b0bd2fd295c9",
+                "sha256:6d5719abd4e1ed13cd0e47d0ace5c0cca7859cb14bcca0429dee842c69fc0527",
+                "sha256:7ad5bfdcc67be964f51c464f3e0e315e7bab647ea726c7662c560fa110d5b0df",
+                "sha256:8bc99f175d7ea42b5faf18f3b503423bce4631c3605f699e014232cc329fb14e",
+                "sha256:9ea6ca24c06931cbc185e10660bbaf6ef2b5a5b276af3335fc5700a62e23119e",
+                "sha256:a00e96ec4e936cd29c3a7d9d0fe4f4ca0b8f058613d0f27eca9a384ca4f340f0",
+                "sha256:ab90e8a162c6c9eca669d90f2c83add7920a3abb69db30ef03205a1ecb6edc53",
+                "sha256:adbc25baf8369cae5bb1aa2188c14b3afdd6fcdb7bde157f27380494ac6a2987",
+                "sha256:af10602f7cf2523443d9d11aacae29afa8f9c9ef0147218bc6cf656dbdda021c",
+                "sha256:ccbe6474a7c8530216f8acb9b7d46045a388900919d2d713c43efe39955b3c4a",
+                "sha256:f9cd599d3847f245fd334289fbcc8d9e4c8c600fa0dbc4eacb31fb00cb0d40b6",
+                "sha256:ff4721af669e84fe71f32564b067e022d35c1abc366df46aba0f9ed6ed7dd7b9"
+            ],
+            "index": "pypi",
+            "version": "==3.4.7"
         },
         "phonenumbers": {
             "hashes": [

--- a/idunn/api/instant_answer.py
+++ b/idunn/api/instant_answer.py
@@ -1,5 +1,6 @@
 import logging
 from fastapi import HTTPException, Query
+from fastapi.responses import ORJSONResponse
 from fastapi.concurrency import run_in_threadpool
 from typing import Optional, List, Tuple
 from pydantic import BaseModel, Field, validator, HttpUrl
@@ -65,8 +66,10 @@ class InstantAnswerResponse(BaseModel):
 
 
 def build_response(result: InstantAnswerResult, query: str, lang: str):
-    return InstantAnswerResponse(
-        data=InstantAnswerData(result=result, query=InstantAnswerQuery(query=query, lang=lang))
+    return ORJSONResponse(
+        InstantAnswerResponse(
+            data=InstantAnswerData(result=result, query=InstantAnswerQuery(query=query, lang=lang)),
+        ).dict()
     )
 
 


### PR DESCRIPTION
See https://fastapi.tiangolo.com/advanced/custom-response/?h=orjson#use-orjsonresponse   
and https://fastapi.tiangolo.com/advanced/response-directly/ 
for more details about this change.

This also prevents a double validation after `InstantAnswerResponse` has been created in `build_response`. By default, FastAPI would re-validate the response model when creating the JSON response.