### PR TITLE
Use standard CORSMiddleware instead of custom implementation

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,8 @@ from idunn import settings
 from idunn.api.urls import get_api_urls
 from idunn.utils.encoders import override_datetime_encoder
 from idunn.utils.prometheus import handle_errors
-from fastapi import FastAPI, APIRouter, Request
+from fastapi import FastAPI, APIRouter
+from fastapi.middleware.cors import CORSMiddleware
 import uvicorn
 from urllib.parse import urlparse
 
@@ -21,14 +22,12 @@ app = FastAPI(
 v1_routes = get_api_urls(settings)
 app.include_router(APIRouter(routes=v1_routes), prefix="/v1")
 
-
-@app.middleware("http")
-async def db_session_middleware(request: Request, call_next):
-    response = await call_next(request)
-    # TODO: only set it when there is an Origin header!
-    response.headers["Access-Control-Allow-Origin"] = "*"
-    return response
-
+# Configure CORS
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings["CORS_ALLOW_ORIGINS"].split(","),
+    allow_headers=settings["CORS_ALLOW_HEADERS"].split(","),
+)
 
 # Override FastAPI defaults
 app.add_exception_handler(Exception, handle_errors)

--- a/idunn/api/places.py
+++ b/idunn/api/places.py
@@ -2,7 +2,7 @@ import logging
 import urllib.parse
 from enum import Enum
 from starlette.datastructures import URL
-from fastapi import HTTPException, BackgroundTasks, Request, Response, Query
+from fastapi import HTTPException, BackgroundTasks, Request, Query
 from fastapi.responses import JSONResponse
 from typing import Optional
 from pydantic import confloat
@@ -124,16 +124,3 @@ def get_place_latlon(
         closest_place = None
     place = Latlon(lat, lon, closest_address=closest_place)
     return place.load_place(lang, verbosity)
-
-
-def handle_option(id, request: Request):  # pylint: disable = unused-argument
-    response = Response()
-    if settings.get("CORS_OPTIONS_REQUESTS_ENABLED", False) is True:
-        response.headers["Access-Control-Allow-Origin"] = "*"
-        response.headers["Access-Control-Allow-Headers"] = request.headers.get(
-            "Access-Control-Request-Headers", "*"
-        )
-        response.headers["Access-Control-Allow-Methods"] = "GET"
-    else:
-        response.status_code = 405
-    return response

--- a/idunn/api/urls.py
+++ b/idunn/api/urls.py
@@ -1,5 +1,5 @@
 from .pois import get_poi
-from .places import get_place, get_place_latlon, handle_option
+from .places import get_place, get_place_latlon
 from .status import get_status
 from .places_list import get_places_bbox, get_events_bbox, PlacesBboxResponse
 from .categories import AllCategoriesResponse, get_all_categories
@@ -44,7 +44,6 @@ def get_api_urls(settings):
             responses={400: {"description": "Client Error in query params"}},
         ),
         APIRoute("/places/latlon:{lat}:{lon}", get_place_latlon, response_model=Place),
-        APIRoute("/places/{id}", handle_option, methods=["OPTIONS"], include_in_schema=False),
         APIRoute("/places/{id}", get_place, response_model=Place),
         # Categories
         APIRoute("/categories", get_all_categories, response_model=AllCategoriesResponse),

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -103,7 +103,8 @@ WEATHER_CACHE_TIMEOUT: 300 # seconds
 
 #######################
 ## CORS
-CORS_OPTIONS_REQUESTS_ENABLED: False
+CORS_ALLOW_ORIGINS: "*"
+CORS_ALLOW_HEADERS: "*"
 
 #######################
 ## Directions

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -26,7 +26,6 @@ def test_undefined_wheelchairs():
     response = client.get(url="http://localhost/v1/pois/osm:node:738042332?lang=fr")
 
     assert response.status_code == 200
-    assert response.headers.get("Access-Control-Allow-Origin") == "*"
 
     resp = response.json()
 
@@ -48,7 +47,6 @@ def test_wheelchair():
     response = client.get(url="http://localhost/v1/pois/osm:node:36153811?lang=fr")
 
     assert response.status_code == 200
-    assert response.headers.get("Access-Control-Allow-Origin") == "*"
 
     resp = response.json()
 

--- a/tests/test_places.py
+++ b/tests/test_places.py
@@ -21,7 +21,6 @@ def test_full_query_admin():
     client = TestClient(app)
     response = client.get(url="http://localhost/v1/places/admin:osm:relation:123057?lang=fr")
     assert response.status_code == 200
-    assert response.headers.get("Access-Control-Allow-Origin") == "*"
 
     resp = response.json()
 
@@ -66,7 +65,6 @@ def test_full_query_street():
     response = client.get(url="http://localhost/v1/places/street:35460343?lang=fr")
 
     assert response.status_code == 200
-    assert response.headers.get("Access-Control-Allow-Origin") == "*"
 
     resp = response.json()
 
@@ -146,7 +144,6 @@ def test_full_query_address():
     response = client.get(url=f"http://localhost/v1/places/{id_moulin}?lang=fr")
 
     assert response.status_code == 200
-    assert response.headers.get("Access-Control-Allow-Origin") == "*"
 
     resp = response.json()
 
@@ -225,7 +222,6 @@ def test_full_query_poi():
     response = client.get(url="http://localhost/v1/places/osm:way:63178753?lang=fr")
 
     assert response.status_code == 200
-    assert response.headers.get("Access-Control-Allow-Origin") == "*"
 
     resp = response.json()
 
@@ -364,7 +360,6 @@ def test_type_query_admin():
         url="http://localhost/v1/places/admin:osm:relation:123057?lang=fr&type=admin",
     )
     assert response.status_code == 200
-    assert response.headers.get("Access-Control-Allow-Origin") == "*"
 
     resp = response.json()
 
@@ -392,7 +387,6 @@ def test_type_query_street():
     response = client.get(url="http://localhost/v1/places/street:35460343?lang=fr&type=street")
 
     assert response.status_code == 200
-    assert response.headers.get("Access-Control-Allow-Origin") == "*"
 
     resp = response.json()
 
@@ -407,7 +401,6 @@ def test_type_query_address():
     response = client.get(url=f"http://localhost/v1/places/{id_moulin}?lang=fr&type=address")
 
     assert response.status_code == 200
-    assert response.headers.get("Access-Control-Allow-Origin") == "*"
 
     resp = response.json()
 
@@ -420,7 +413,6 @@ def test_type_query_poi():
     response = client.get(url="http://localhost/v1/places/osm:way:63178753?lang=fr&type=poi")
 
     assert response.status_code == 200
-    assert response.headers.get("Access-Control-Allow-Origin") == "*"
 
     resp = response.json()
 
@@ -483,7 +475,6 @@ def test_basic_short_query_poi():
         url="http://localhost/v1/places/osm:way:63178753?lang=fr&verbosity=short",
     )
     assert response.status_code == 200
-    assert response.headers.get("Access-Control-Allow-Origin") == "*"
 
     resp = response.json()
 

--- a/tests/test_wiki_images.py
+++ b/tests/test_wiki_images.py
@@ -27,7 +27,6 @@ def test_orsay_images():
     response = client.get(url="http://localhost/v1/places/osm:way:63178753?lang=fr")
 
     assert response.status_code == 200
-    assert response.headers.get("Access-Control-Allow-Origin") == "*"
     resp = response.json()
 
     assert resp["blocks"][4]["type"] == "images"
@@ -47,7 +46,6 @@ def test_image_for_unnamed_poi():
     response = client.get(url="http://localhost/v1/places/osm:way:63178753?lang=fr")
 
     assert response.status_code == 200
-    assert response.headers.get("Access-Control-Allow-Origin") == "*"
     resp = response.json()
 
     assert resp["blocks"][4]["type"] == "images"


### PR DESCRIPTION
[`CORSMiddleware`](https://fastapi.tiangolo.com/tutorial/cors/#cors-cross-origin-resource-sharing) is provided by FastAPI (actually reexported from Starlette).

Its behavior complies better with the standard. Especially, `Access-Control-Allow-Origin` header will be returned only when `Origin` is defined in the request.
