### PR TITLE
Fix LegacyPjSource to use CategoryEnum methods

### DIFF
--- a/idunn/datasources/pages_jaunes.py
+++ b/idunn/datasources/pages_jaunes.py
@@ -12,6 +12,7 @@ from idunn.places.models import pj_info, pj_find
 from idunn.places.exceptions import PlaceNotFound
 from idunn.utils.auth_session import AuthSession
 from idunn.utils.geometry import bbox_inside_polygon, france_polygon
+from idunn.api.utils import CategoryEnum
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +36,7 @@ class PjSource:
     def internal_id(self, poi_id):
         return poi_id.replace(f"{self.PLACE_ID_NAMESPACE}:", "", 1)
 
-    def get_places_bbox(self, categories, bbox, size=10, query=""):
+    def get_places_bbox(self, categories: List[CategoryEnum], bbox, size=10, query=""):
         raise NotImplementedError
 
     def get_place(self, poi_id):
@@ -56,8 +57,8 @@ class LegacyPjSource(PjSource):
         else:
             self.enabled = False
 
-    def get_places_bbox(self, categories, bbox, size=10, query=""):
-        raw_categories = [pj_category for c in categories for pj_category in c["pj_filters"]]
+    def get_places_bbox(self, categories: List[CategoryEnum], bbox, size=10, query=""):
+        raw_categories = [pj_category for c in categories for pj_category in c.pj_filters()]
         left, bot, right, top = bbox
 
         body = {
@@ -144,7 +145,9 @@ class ApiPjSource(PjSource):
 
         return pois
 
-    def get_places_bbox(self, categories, bbox, size=10, query="") -> List[PjApiPOI]:
+    def get_places_bbox(
+        self, categories: List[CategoryEnum], bbox, size=10, query=""
+    ) -> List[PjApiPOI]:
         query_params = {
             "what": " ".join(c.pj_what() for c in categories),
             "where": self.format_where(bbox),

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -629,3 +629,16 @@ def test_endpoint_categories():
 
     assert categories[0] == {"name": "restaurant", "raw_filters": ["restaurant,*", "fast_food,*"]}
     assert categories[1] == {"name": "hotel", "raw_filters": ["*,hotel"]}
+
+
+@pytest.mark.parametrize(
+    "enable_pj_source", [("legacy", "musee_picasso_short")], indirect=True,
+)
+def test_pj_categories_filter_legacy(enable_pj_source):
+    client = TestClient(app)
+    response = client.get(url=f"http://localhost/v1/places?bbox={BBOX_PARIS}&category=museum")
+    assert response.status_code == 200
+    resp = response.json()
+    assert len(resp["places"]) == 1
+    assert resp["places"][0]["id"] == "pj:05360257"
+    assert resp["places"][0]["name"] == "Musée Picasso"

--- a/tests/test_pj_poi.py
+++ b/tests/test_pj_poi.py
@@ -29,18 +29,24 @@ def enable_pj_source(request):
 
     with override_settings(updated_settings), init_pj_source(source_type):
         if method == "legacy":
-            api_mock = mock.patch.object(
+            mock_search = mock.patch.object(
                 places_utils.pj_source.es,
                 "search",
                 new=lambda *x, **y: {"hits": {"hits": [api_result]}},
             )
+            mock_search_template = mock.patch.object(
+                places_utils.pj_source.es,
+                "search_template",
+                new=lambda *x, **y: {"hits": {"hits": [api_result]}},
+            )
+            with mock_search, mock_search_template:
+                yield
         else:
             api_mock = mock.patch.object(
                 places_utils.pj_source, "get_from_params", new=lambda *x, **y: api_result,
             )
-
-        with api_mock:
-            yield
+            with api_mock:
+                yield
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
An oversight in #174 that could not be noticed in environment where the legacy source is no longer used.