### PR TITLE
Instant answer: normalization by removing common patterns in queries

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -161,7 +161,10 @@ disable=print-statement,
 # NOTE: Doesn't operate well with pydantic's decorator `validator`
 #       https://github.com/samuelcolvin/pydantic/issues/568
         no-self-argument,
-        no-self-use
+        no-self-use,
+# NOTE: Reports false positive with assignment expression
+# https://github.com/PyCQA/pylint/issues/3249
+        superfluous-parens,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/idunn/instant_answer/__init__.py
+++ b/idunn/instant_answer/__init__.py
@@ -1,0 +1,1 @@
+from .normalization import normalize

--- a/idunn/instant_answer/normalization.py
+++ b/idunn/instant_answer/normalization.py
@@ -1,0 +1,15 @@
+import re
+from pathlib import Path
+
+patterns_path = Path(__file__).with_name("patterns_to_ignore.txt")
+with open(patterns_path) as file:
+    patterns = [p for line in file if (p := line.strip())]
+    ignore_pattern_start = re.compile(rf'^({"|".join(patterns)})( +|$)')
+    ignore_pattern_end = re.compile(rf' +({"|".join(patterns)})$')
+
+
+def normalize(query):
+    query = query.strip().lower()
+    query = ignore_pattern_start.sub("", query)
+    query = ignore_pattern_end.sub("", query)
+    return query

--- a/idunn/instant_answer/patterns_to_ignore.txt
+++ b/idunn/instant_answer/patterns_to_ignore.txt
@@ -1,0 +1,25 @@
+qwant ?maps?
+maps? qwant
+google ?maps?
+maps? google
+maps?( of)?
+carte( des?| du)?
+plan( de| du)?
+add?resse?
+((num(e|é)ro)|n(o|°)?)( de)? ?t(e|é)l(e|é)phone
+num(e|é)ro$
+t(e|é)l(e|é)phone
+horaires?( (d('| ))?ouvertures?)?
+(prendre )?rdv
+avis
+menu$
+commune de
+quartier de
+ville de
+code postale?
+(google )?street ?view
+itin(e|é)raires?
+lieu dit
+localisation
+o(ù|u) (se|ce) (trouve|situe)( (le|la))?
+where is

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -171,3 +171,7 @@ RECYCLING_MAX_DISTANCE_AROUND_POI: 100 # meters
 RECYCLING_DATA_STORE_IN_CACHE: True # Recycling data will be cached if Redis is configured
 RECYCLING_DATA_EXPIRE: 1800 # seconds
 RECYCLING_MEASURES_MAX_AGE_IN_HOURS: 168 # 7 days (Older measures will be ignored)
+
+##########################
+## Instant Answer
+IA_SUCCESS_ON_GENERIC_QUERIES: False

--- a/idunn/utils/maps_urls.py
+++ b/idunn/utils/maps_urls.py
@@ -6,6 +6,13 @@ from idunn.geocoder.models.geocodejson import IntentionFilter
 MAPS_BASE_URL = settings["MAPS_BASE_URL"]
 
 
+def get_default_url(no_ui=False):
+    url = MAPS_BASE_URL
+    if no_ui:
+        url += "?no_ui=1"
+    return url
+
+
 def get_place_url(place_id, no_ui=False):
     url = f"{MAPS_BASE_URL}place/{place_id}"
     if no_ui:

--- a/tests/test_instant_answer/test_ia_api.py
+++ b/tests/test_instant_answer/test_ia_api.py
@@ -4,7 +4,7 @@ import pytest
 from fastapi.testclient import TestClient
 from app import app
 
-from .fixtures.autocomplete import (
+from ..fixtures.autocomplete import (
     mock_autocomplete_get,
     mock_NLU_with_city,
     mock_NLU_with_brand_and_city,

--- a/tests/test_instant_answer/test_ia_normalization.py
+++ b/tests/test_instant_answer/test_ia_normalization.py
@@ -1,0 +1,14 @@
+from idunn.instant_answer import normalize
+
+
+def test_normalization():
+    assert normalize("Strasbourg") == "strasbourg"
+    assert normalize("map Strasbourg") == "strasbourg"
+    assert normalize("strasbourg maps") == "strasbourg"
+    assert normalize("horaires musée picasso") == "musée picasso"
+    assert normalize("mapabcd") == "mapabcd"
+    assert normalize("prendre rdv dentiste rennes") == "dentiste rennes"
+    assert normalize("où se situe Limoges") == "limoges"
+    assert normalize("ou se trouve la tour Eiffel") == "tour eiffel"
+    assert normalize("qwantmaps") == ""
+    assert normalize("Restaurants lille avis") == "restaurants lille"


### PR DESCRIPTION
This PR introduces
* a "patterns_to_ignore.txt " file, with regex to remove at the start and end of queries for instant answers
* a new flag `IA_SUCCESS_ON_GENERIC_QUERIES`, to return a successful response with empty results on queries with no substantial input. This is useful when the client would like to handle that case specifically, with a generic map for example.
