### PR TITLE
Website block: always return a 'label', use domain name by default

### DIFF
--- a/idunn/blocks/website.py
+++ b/idunn/blocks/website.py
@@ -1,12 +1,13 @@
-from .base import BaseBlock
+from urllib.parse import urlparse
+from typing import Literal
 
-from typing import Optional, Literal
+from .base import BaseBlock
 
 
 class WebSiteBlock(BaseBlock):
     type: Literal["website"] = "website"
     url: str
-    label: Optional[str]
+    label: str
 
     @classmethod
     def from_es(cls, place, lang):
@@ -15,5 +16,9 @@ class WebSiteBlock(BaseBlock):
 
         if not website:
             return None
+
+        if not label:
+            # Extract domain name or hostname from website
+            label = urlparse(website).netloc
 
         return cls(url=website, label=label)

--- a/idunn/places/pj_poi.py
+++ b/idunn/places/pj_poi.py
@@ -273,8 +273,12 @@ class PjApiPOI(BasePlace):
         return resolve_url(self.data.website_urls[0].website_url)
 
     def get_website_label(self):
-        if isinstance(self.data, pj_find.Listing) or not self.data.website_urls:
+        if not self.data.website_urls:
             return None
+
+        if isinstance(self.data, pj_find.Listing):
+            # FIXME: Ideally the Listing would include a "suggested_label" too
+            return self.get_local_name()
 
         suggested_label = self.data.website_urls[0].suggested_label
         prefix = "Voir le site "

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -87,7 +87,11 @@ def test_bbox():
                         "local_format": "01 40 49 48 14",
                         "url": "tel:+33140494814",
                     },
-                    {"type": "website", "url": "http://www.musee-orsay.fr", "label": None},
+                    {
+                        "type": "website",
+                        "url": "http://www.musee-orsay.fr",
+                        "label": "www.musee-orsay.fr",
+                    },
                 ],
                 "meta": {
                     "source": "osm",
@@ -118,7 +122,7 @@ def test_bbox():
                     {
                         "type": "website",
                         "url": "http://www.paris.catholique.fr/-Notre-Dame-des-Blancs-Manteaux,1290-.html",
-                        "label": None,
+                        "label": "www.paris.catholique.fr",
                     },
                 ],
                 "meta": ANY,
@@ -195,7 +199,7 @@ def test_bbox():
                         "type": "phone",
                         "url": "tel:+33140205229",
                     },
-                    {"type": "website", "url": "http://www.louvre.fr", "label": None},
+                    {"type": "website", "url": "http://www.louvre.fr", "label": "www.louvre.fr"},
                 ],
                 "meta": ANY,
             },
@@ -292,7 +296,11 @@ def test_size_list():
                         "type": "phone",
                         "url": "tel:+33140494814",
                     },
-                    {"type": "website", "url": "http://www.musee-orsay.fr", "label": None},
+                    {
+                        "type": "website",
+                        "url": "http://www.musee-orsay.fr",
+                        "label": "www.musee-orsay.fr",
+                    },
                 ],
                 "meta": ANY,
             }
@@ -424,7 +432,7 @@ def test_single_raw_filter():
                     {
                         "type": "website",
                         "url": "http://www.paris.catholique.fr/-Notre-Dame-des-Blancs-Manteaux,1290-.html",
-                        "label": None,
+                        "label": "www.paris.catholique.fr",
                     },
                 ],
                 "meta": ANY,

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -152,7 +152,7 @@ def test_full(mock_external_requests):
                     }
                 ],
             },
-            {"type": "website", "url": "http://testing.test", "label": None},
+            {"type": "website", "url": "http://testing.test", "label": "testing.test"},
             {"type": "contact", "url": "mailto:contact@example.com",},
         ],
         "meta": {

--- a/tests/test_places.py
+++ b/tests/test_places.py
@@ -350,7 +350,7 @@ def test_full_query_poi():
                 }
             ],
         },
-        {"type": "website", "url": "http://www.musee-orsay.fr", "label": None},
+        {"type": "website", "url": "http://www.musee-orsay.fr", "label": "www.musee-orsay.fr"},
     ]
 
 

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -7,4 +7,6 @@ def test_website_block():
         POI({"properties": {"contact:website": "http://www.pershinghall.com"}}), lang="en"
     )
 
-    assert web_block == WebSiteBlock(url="http://www.pershinghall.com")
+    assert web_block == WebSiteBlock(
+        url="http://www.pershinghall.com", label="www.pershinghall.com",
+    )


### PR DESCRIPTION
To simplify client-side implementations, the `website` block will always contain a non-empty `label`.