### PR TITLE
simplify complex categories

### DIFF
--- a/idunn/utils/categories.yml
+++ b/idunn/utils/categories.yml
@@ -29,7 +29,6 @@ categories:
             - "salles de cinéma"
         raw_filters:
             - "cinema,*"
-        regex: "^cine"
     theatre:
         pj_what: "théatre"
         pj_filters:
@@ -45,7 +44,7 @@ categories:
             - "pharmacy,*"
         regex: "pharmac"
     supermarket:
-        pj_what: "supermarchés"
+        pj_what: "alimentation"
         pj_filters:
             - "supermarchés, hypermarchés"
         raw_filters:
@@ -60,7 +59,7 @@ categories:
             - "bank,*"
         regex: "^(bank|banque|credit|caisse|atm$)"
     education:
-        pj_what: "école"
+        pj_what: "école collège lycée"
         pj_filters:
             - "écoles maternelles publiques"
             - "écoles primaires publiques"
@@ -121,7 +120,7 @@ categories:
             - "services de gendarmerie, de police"
         raw_filters:
             - "police,*"
-        regex: "(^| )poli"
+        regex: "(^| )(poli|gendar)"
     fitness:
         pj_what: "sport"
         pj_filters:

--- a/idunn/utils/categories.yml
+++ b/idunn/utils/categories.yml
@@ -14,15 +14,20 @@ categories:
         raw_filters:
             - "*,hotel"
         regex: "hotel"
-    leisure:
-        pj_what: "loisir"
+    cinema:
+        pj_what: "cinéma"
         pj_filters:
             - "salles de cinéma"
-            - "salles de concerts, de spectacles"
         raw_filters:
             - "cinema,*"
+        regex: "^cine"
+    theatre:
+        pj_what: "théatre"
+        pj_filters:
+            - "salles de concerts, de spectacles"
+        raw_filters:
             - "theatre,*"
-        regex: "^cine|leisure|loisir|theat"
+        regex: "^theat"
     pharmacy:
         pj_what: "pharmacie"
         pj_filters:
@@ -31,7 +36,7 @@ categories:
             - "pharmacy,*"
         regex: "pharmac"
     supermarket:
-        pj_what: "supermarchés hypermarchés"
+        pj_what: "supermarchés"
         pj_filters:
             - "supermarchés, hypermarchés"
         raw_filters:
@@ -46,7 +51,7 @@ categories:
             - "bank,*"
         regex: "^(bank|banque|credit|caisse|atm$)"
     education:
-        pj_what: "scolaire"
+        pj_what: "école"
         pj_filters:
             - "écoles maternelles publiques"
             - "écoles primaires publiques"
@@ -63,7 +68,7 @@ categories:
             - "college,*"
         regex: "^ecole|^college|^universit|educat"
     bar:
-        pj_what: "cafés bars"
+        pj_what: "bars"
         pj_filters:
             - "cafés, bars"
         raw_filters:
@@ -78,7 +83,7 @@ categories:
             - "museum,*"
         regex: "^(museum|musee)"
     health:
-        pj_what: "santé"
+        pj_what: "hopital"
         pj_filters:
             - "Centre médico-social"
             - "Chirurgien-dentiste"
@@ -93,22 +98,21 @@ categories:
     service:
         pj_what: "poste"
         pj_filters:
-            - "plombiers"
-            - "garages automobiles"
             - "envoi, distribution de courrier, de colis"
-            - "serrurerie, métallerie"
-            - "dépannage serrurerie"
-            - "mairies"
-            - "services de gendarmerie, de police"
-            - "sapeurs-pompiers, centres de secours"
-            - "préfectures, sous-préfectures"
         raw_filters:
             - "car_repair,*"
             - "post_office,*"
             - "townhall,*"
             - "police,*"
             - "fire_station,*"
-        regex: "service|car repair|post office|police|garage|poste|gendarmerie|pompiers"
+        regex: "(^| )post"
+    police:
+        pj_what: "police"
+        pj_filters:
+            - "services de gendarmerie, de police"
+        raw_filters:
+            - "police,*"
+        regex: "(^| )poli"
     fitness:
         pj_what: "sport"
         pj_filters:

--- a/idunn/utils/categories.yml
+++ b/idunn/utils/categories.yml
@@ -120,7 +120,7 @@ categories:
             - "services de gendarmerie, de police"
         raw_filters:
             - "police,*"
-        regex: "(^| )(poli|gendar)"
+        regex: "(^| )(police|gendar)"
     fitness:
         pj_what: "sport"
         pj_filters:

--- a/idunn/utils/categories.yml
+++ b/idunn/utils/categories.yml
@@ -21,6 +21,15 @@ categories:
         raw_filters:
             - "cinema,*"
         regex: "^cine"
+    # NOTE: This is a legacy alias of `cinema`.
+    #       It may be removed once erdapfel don't rely on it anymore.
+    leisure:
+        pj_what: "cinéma"
+        pj_filters:
+            - "salles de cinéma"
+        raw_filters:
+            - "cinema,*"
+        regex: "^cine"
     theatre:
         pj_what: "théatre"
         pj_filters:

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -544,7 +544,7 @@ def test_valid_category():
     """
     client = TestClient(app)
 
-    response = client.get(url=f"http://localhost/v1/places?bbox={BBOX_BREST}&category=leisure")
+    response = client.get(url=f"http://localhost/v1/places?bbox={BBOX_BREST}&category=cinema")
 
     assert response.status_code == 200
 
@@ -582,7 +582,7 @@ def test_places_with_explicit_source_osm(enable_pj_source):
     """
     client = TestClient(app)
     response = client.get(
-        url=f"http://localhost/v1/places?bbox={BBOX_BREST}&category=leisure&source=osm"
+        url=f"http://localhost/v1/places?bbox={BBOX_BREST}&category=cinema&source=osm"
     )
 
     assert response.status_code == 200

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -544,7 +544,7 @@ def test_valid_category():
     """
     client = TestClient(app)
 
-    response = client.get(url=f"http://localhost/v1/places?bbox={BBOX_BREST}&category=cinema")
+    response = client.get(url=f"http://localhost/v1/places?bbox={BBOX_BREST}&category=leisure")
 
     assert response.status_code == 200
 
@@ -582,7 +582,7 @@ def test_places_with_explicit_source_osm(enable_pj_source):
     """
     client = TestClient(app)
     response = client.get(
-        url=f"http://localhost/v1/places?bbox={BBOX_BREST}&category=cinema&source=osm"
+        url=f"http://localhost/v1/places?bbox={BBOX_BREST}&category=leisure&source=osm"
     )
 
     assert response.status_code == 200


### PR DESCRIPTION
Simplify categories that require a non-trivial request to the source.

There is some arbitrary stuff going on, but it should be simpler to discuss it now that there is a base suggestion.