### PR TITLE
Define source_url and contribute_url in place meta

### DIFF
--- a/idunn/places/base.py
+++ b/idunn/places/base.py
@@ -196,10 +196,18 @@ class BasePlace(dict):
     def get_source(self):
         return None
 
+    def get_source_url(self):
+        return None
+
+    def get_contribute_url(self):
+        return None
+
     def get_meta(self):
         place_id = self.get_id()
         return PlaceMeta(
             source=self.get_source(),
+            source_url=self.get_source_url(),
+            contribute_url=self.get_contribute_url(),
             maps_place_url=maps_urls.get_place_url(place_id),
             maps_directions_url=maps_urls.get_directions_url(place_id),
         )

--- a/idunn/places/models/pj_find.py
+++ b/idunn/places/models/pj_find.py
@@ -68,12 +68,14 @@ class Reviews(BaseModel):
 class Urls(BaseModel):
     """
     Omitted fields:
-      - merchant_url: Link to the merchant page on PagesJaunes.fr
       - map_url: Link to the map URL on PagesJaunes.fr
       - immersive_url: (Deprecated) Link to the immersive view on PagesJaunes.fr
       - itinerary_url: Link to the detailed route to that place.fr
     """
 
+    merchant_url: Optional[str] = Field(
+        None, description="Link to the merchant page on PagesJaunes.fr"
+    )
     reviews_url: Optional[str] = Field(
         None, description="Link to the business reviews on PagesJaunes.fr"
     )

--- a/idunn/places/models/pj_info.py
+++ b/idunn/places/models/pj_info.py
@@ -79,12 +79,14 @@ class Schedules(BaseModel):
 class Urls(BaseModel):
     """
     Omitted fields:
-      - merchant_url: Link to the merchant page on PagesJaunes.fr
       - map_url: Link to the map URL on PagesJaunes.fr
       - immersive_url: Link to the immersive view on PagesJaunes.fr
       - itinerary_url: Link to the detailed route to that place.fr
     """
 
+    merchant_url: Optional[str] = Field(
+        None, description="Link to the merchant page on PagesJaunes.fr"
+    )
     reviews_url: Optional[str] = Field(
         None, description="Link to the business reviews on PagesJaunes.fr"
     )

--- a/idunn/places/pj_poi.py
+++ b/idunn/places/pj_poi.py
@@ -220,6 +220,12 @@ class PjPOI(BasePlace):
     def get_source(self):
         return PoiSource.PAGESJAUNES
 
+    def get_source_url(self):
+        business_id = self.get("BusinessId")
+        if not business_id:
+            return None
+        return f"https://www.pagesjaunes.fr/pros/{business_id}"
+
     def get_raw_grades(self):
         return self.get("grades")
 
@@ -387,6 +393,16 @@ class PjApiPOI(BasePlace):
 
     def get_source(self):
         return PoiSource.PAGESJAUNES
+
+    def get_source_url(self):
+        return next(
+            (
+                ins.urls.merchant_url
+                for ins in self.data.inscriptions
+                if ins.urls and ins.urls.merchant_url
+            ),
+            None,
+        )
 
     def get_raw_grades(self):
         grade_count = sum(

--- a/idunn/places/place.py
+++ b/idunn/places/place.py
@@ -5,6 +5,10 @@ from typing import List, Optional
 
 class PlaceMeta(BaseModel):
     source: Optional[str]
+    source_url: Optional[str] = Field(description="URL to the place details at the source")
+    contribute_url: Optional[str] = Field(
+        description="Url to edit place details. Defined for OSM POIs only."
+    )
     maps_place_url: HttpUrl = Field(description="Direct URL to the place details on Qwant Maps.")
     maps_directions_url: HttpUrl = Field(
         description=(

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -86,6 +86,9 @@ PJ_ES_QUERY_TEMPLATE: "pagesjaunes_query"
 PJ_API_ID:
 PJ_API_SECRET:
 
+# OSM
+OSM_CONTRIBUTION_HASHTAGS: "QwantMaps" # separated by ",". Used in osm.org/edit URL.
+
 #######################
 ## Data Publishing
 

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -95,6 +95,8 @@ def test_bbox():
                 ],
                 "meta": {
                     "source": "osm",
+                    "source_url": "https://www.openstreetmap.org/way/63178753",
+                    "contribute_url": "https://www.openstreetmap.org/edit?way=63178753&hashtags=QwantMaps",
                     "maps_place_url": "https://www.qwant.com/maps/place/osm:way:63178753",
                     "maps_directions_url": "https://www.qwant.com/maps/routes/?destination=osm%3Away%3A63178753",
                 },
@@ -563,7 +565,13 @@ def test_valid_category():
                 "geometry": ANY,
                 "address": ANY,
                 "blocks": [],
-                "meta": {"source": "osm", "maps_place_url": ANY, "maps_directions_url": ANY,},
+                "meta": {
+                    "source": "osm",
+                    "source_url": ANY,
+                    "contribute_url": ANY,
+                    "maps_place_url": ANY,
+                    "maps_directions_url": ANY,
+                },
             }
         ],
         "bbox": ANY,
@@ -601,7 +609,13 @@ def test_places_with_explicit_source_osm(enable_pj_source):
                 "geometry": ANY,
                 "address": ANY,
                 "blocks": [],
-                "meta": {"source": "osm", "maps_place_url": ANY, "maps_directions_url": ANY,},
+                "meta": {
+                    "source": "osm",
+                    "source_url": ANY,
+                    "contribute_url": ANY,
+                    "maps_place_url": ANY,
+                    "maps_directions_url": ANY,
+                },
             }
         ],
         "bbox": ANY,

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -157,6 +157,8 @@ def test_full(mock_external_requests):
         ],
         "meta": {
             "source": "osm",
+            "source_url": "https://www.openstreetmap.org/way/7777778",
+            "contribute_url": "https://www.openstreetmap.org/edit?way=7777778&hashtags=QwantMaps",
             "maps_place_url": "https://www.qwant.com/maps/place/osm:way:7777778",
             "maps_directions_url": "https://www.qwant.com/maps/routes/?destination=osm%3Away%3A7777778",
         },

--- a/tests/test_places.py
+++ b/tests/test_places.py
@@ -51,6 +51,8 @@ def test_full_query_admin():
         "blocks": [],
         "meta": {
             "source": None,
+            "source_url": None,
+            "contribute_url": None,
             "maps_place_url": "https://www.qwant.com/maps/place/admin:osm:relation:123057",
             "maps_directions_url": "https://www.qwant.com/maps/routes/?destination=admin%3Aosm%3Arelation%3A123057",
         },
@@ -128,6 +130,8 @@ def test_full_query_street():
         "blocks": [],
         "meta": {
             "source": None,
+            "source_url": None,
+            "contribute_url": None,
             "maps_place_url": "https://www.qwant.com/maps/place/street:35460343",
             "maps_directions_url": "https://www.qwant.com/maps/routes/?destination=street%3A35460343",
         },
@@ -207,6 +211,8 @@ def test_full_query_address():
         "blocks": [],
         "meta": {
             "source": None,
+            "source_url": None,
+            "contribute_url": None,
             "maps_place_url": "https://www.qwant.com/maps/place/addr:5.108632;48.810273",
             "maps_directions_url": "https://www.qwant.com/maps/routes/?destination=addr%3A5.108632%3B48.810273",
         },


### PR DESCRIPTION
In the `meta` object:
* `source_url` is a direct URL to the place details
* `contribute_url` is defined for OSM POIs only