### PR TITLE
Add 'email' field in contact block

### DIFF
--- a/idunn/blocks/contact.py
+++ b/idunn/blocks/contact.py
@@ -5,6 +5,7 @@ from typing import Literal
 class ContactBlock(BaseBlock):
     type: Literal["contact"] = "contact"
     url: str
+    email: str
 
     @classmethod
     def from_es(cls, place, lang):
@@ -13,4 +14,4 @@ class ContactBlock(BaseBlock):
         if not mail or not isinstance(mail, str):
             return None
 
-        return cls(url=f"mailto:{mail}")
+        return cls(url=f"mailto:{mail}", email=mail)

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -7,4 +7,6 @@ def test_contact_block():
         POI({"properties": {"contact:email": "info@pershinghall.com"}}), lang="en"
     )
 
-    assert web_block == ContactBlock(url="mailto:info@pershinghall.com")
+    assert web_block == ContactBlock(
+        url="mailto:info@pershinghall.com", email="info@pershinghall.com",
+    )

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -153,7 +153,11 @@ def test_full(mock_external_requests):
                 ],
             },
             {"type": "website", "url": "http://testing.test", "label": "testing.test"},
-            {"type": "contact", "url": "mailto:contact@example.com",},
+            {
+                "type": "contact",
+                "url": "mailto:contact@example.com",
+                "email": "contact@example.com",
+            },
         ],
         "meta": {
             "source": "osm",


### PR DESCRIPTION
Exposes the raw email address, in addition to the "mailto:" URL.