### PR TITLE
result_filter: check translated names

### DIFF
--- a/idunn/utils/result_filter.py
+++ b/idunn/utils/result_filter.py
@@ -112,13 +112,13 @@ def word_matches(query_word, label_word):
 
 def check(
     query: str,
-    name: str,
+    names: List[str],
     admins: List[str] = [],
     postcodes: List[str] = [],
     is_address: bool = True,
 ) -> bool:
     query_words = words(query.lower())
-    name_words = words(name.lower())
+    names = list(map(str.lower, names))
     admins = list(map(str.lower, admins))
 
     if is_address:
@@ -126,7 +126,7 @@ def check(
 
     # Check if all words of the query match a word in the result
     full_label = [
-        *name_words,
+        *(w for name in names for w in words(name)),
         *postcodes,
         *(w for admin in admins for w in words(admin)),
     ]
@@ -135,12 +135,15 @@ def check(
         if not any(word_matches(q_word, l_word) for l_word in full_label):
             logger.info(
                 "Removed `%s` from results because queried `%s` does not match the result",
-                name,
+                names[0],
                 q_word,
             )
             return False
 
-    # Check if at least 2/3 of the result's name is covered by the query
+    # Check if at least 2/3 of the result is covered by the query in one of these cases:
+    #   - over one of the result names
+    #   - over one of the result names together with one of the admin names
+    #   - over one of the result names together with a postcode
     def coverage(terms):
         return sum(
             any(word_matches(query_word, term) for query_word in query_words) for term in terms
@@ -148,6 +151,7 @@ def check(
 
     check_coverage = any(
         coverage(terms) >= (2 / 3)
+        for name_words in map(words, names)
         for terms in [
             name_words,
             *[name_words + words(admin) for admin in admins],
@@ -158,7 +162,7 @@ def check(
     if not check_coverage:
         logger.info(
             "Removed `%s` from results because query `%s` is not accurate enough",
-            name,
+            names[0],
             query,
         )
         return False
@@ -182,9 +186,16 @@ def check_bragi_response(query: str, bragi_response: dict) -> bool:
             }
         )
 
+    name = bragi_response["name"]
+    local_names = [
+        prop["value"]
+        for prop in bragi_response.get("properties", [])
+        if prop["key"].startswith("name:") or prop["key"].startswith("alt_name:")
+    ]
+
     return check(
         query,
-        bragi_response["name"],
+        [name] + local_names,
         [admin["name"] for admin in bragi_response.get("administrative_regions", [])],
         postcodes,
         bragi_response.get("type") == "address",

--- a/idunn/utils/result_filter.py
+++ b/idunn/utils/result_filter.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from functools import lru_cache
 from typing import List
 from unidecode import unidecode
 
@@ -71,6 +72,7 @@ def word_matches_abreviation(word_1, word_2):
     return ABREVIATIONS.get(word_1) == word_2 or ABREVIATIONS.get(word_2) == word_1
 
 
+@lru_cache(10000)
 def word_matches(query_word, label_word):
     """
     Check if two words match with an high degree of confidence.

--- a/tests/fixtures/autocomplete/__init__.py
+++ b/tests/fixtures/autocomplete/__init__.py
@@ -57,7 +57,7 @@ def mock_NLU_with_city(httpx_mock):
 @pytest.fixture
 def mock_autocomplete_get(httpx_mock):
     with override_settings({"BRAGI_BASE_URL": BASE_URL}):
-        httpx_mock.get(re.compile(f"^{BASE_URL}/autocomplete.*q=paris.*")).respond(
+        httpx_mock.get(re.compile(f"^{BASE_URL}/autocomplete.*q=(paris|parigi).*")).respond(
             json=read_fixture("fixtures/autocomplete/paris.json")
         )
 

--- a/tests/fixtures/autocomplete/paris.json
+++ b/tests/fixtures/autocomplete/paris.json
@@ -160,6 +160,10 @@
             48.8155755,
             2.4697602,
             48.902156
+          ],
+          "properties": [
+              {"key": "name:fr", "value":"Paris"},
+              {"key": "name:it", "value": "Parigi"}
           ]
         }
       }

--- a/tests/test_instant_answer/test_ia_api.py
+++ b/tests/test_instant_answer/test_ia_api.py
@@ -23,6 +23,20 @@ def test_ia_paris(mock_autocomplete_get, mock_NLU_with_city):
     assert place["name"] == "Paris"
 
 
+def test_ia_paris_request_international(mock_autocomplete_get, mock_NLU_with_city):
+    """
+    The user queries for the name in Italian while lang = "fr".
+    """
+    client = TestClient(app)
+    response = client.get("/v1/instant_answer", params={"q": "parigi", "lang": "fr"})
+    assert response.status_code == 200
+    response_json = response.json()
+    places = response_json["data"]["result"]["places"]
+    assert len(places) == 1
+    place = places[0]
+    assert place["name"] == "Paris"
+
+
 def test_ia_intention_full_text(
     mock_NLU_with_brand_and_city, mock_autocomplete_get, mock_bragi_carrefour_in_bbox
 ):

--- a/tests/test_result_filter.py
+++ b/tests/test_result_filter.py
@@ -3,7 +3,7 @@ from idunn.utils.result_filter import check
 
 def test_filter():
     place_infos = {
-        "name": "5 rue Gustave Zédé",
+        "names": ["5 rue Gustave Zédé", "5, Zédéstraße"],
         "postcodes": ["79000"],
         "is_address": True,
     }
@@ -41,7 +41,12 @@ def test_filter():
     assert check("5 r gustave zédé", **place_infos)
     assert not check("5 u gustave zédé", **place_infos)
 
+    # Either names can match
+    assert check("5 zédéstraße", **place_infos)
+
     # Queries that match a small part of the request are ignored, postcode and
     # admins matter in relevant matching words.
-    assert not check("101 dalmatiens", name="101 rue des dalmatiens", is_address=True)
-    assert check(query="Paris 2e", name="2e Arrondissement", admins=["Paris"], postcodes=["75002"])
+    assert not check("101 dalmatiens", names=["101 rue des dalmatiens"], is_address=True)
+    assert check(
+        query="Paris 2e", names=["2e Arrondissement"], admins=["Paris"], postcodes=["75002"]
+    )


### PR DESCRIPTION
Read from translation fields while filtering instant answer's output. This should mainly help when the content of the query is not consistent with parameter `lang`.