### PR TITLE
PJ API: Remove places with duplicated merchant_id from results

### DIFF
--- a/idunn/datasources/pages_jaunes.py
+++ b/idunn/datasources/pages_jaunes.py
@@ -160,7 +160,18 @@ class ApiPjSource(PjSource):
             query_params["what"] += " " + query
             query_params["what"] = query_params["what"].strip()
 
-        return self.get_places_from_url(self.PJ_FIND_API_URL, query_params, size)
+        api_places = self.get_places_from_url(self.PJ_FIND_API_URL, query_params, size)
+
+        # Remove duplicated merchant ids that may be returned in different pages
+        merchant_ids = set()
+        places = []
+        for p in api_places:
+            merchant_id = p.data.merchant_id
+            if merchant_id not in merchant_ids:
+                places.append(p)
+                if merchant_id:
+                    merchant_ids.add(merchant_id)
+        return places
 
     def get_place(self, poi_id) -> PjApiPOI:
         try:


### PR DESCRIPTION
It has been noticed that different result pages from the API may contain duplicated POIs.

This PR suggests to remove these duplicated items. As a result, the number of places in the response, may be strictly less than the requested "size", even if more places would have been available in following pages.