### PR TITLE
Anti scraping integration

### DIFF
--- a/idunn/api/instant_answer.py
+++ b/idunn/api/instant_answer.py
@@ -17,6 +17,7 @@ from .constants import PoiSource
 logger = logging.getLogger(__name__)
 
 nlu_allowed_languages = settings["NLU_ALLOWED_LANGUAGES"].split(",")
+ia_max_query_length = int(settings["IA_MAX_QUERY_LENGTH"])
 
 
 class InstantAnswerResult(BaseModel):
@@ -84,7 +85,7 @@ def get_instant_answer_single_place(place_id: str, lang: str):
         place = place_from_id(place_id, follow_redirect=True)
     except Exception as exc:
         logger.warning("Failed to get place for instant answer", exc_info=True)
-        raise HTTPException(status_code=404) from exc
+        raise NoInstantAnswerToDisplay from exc
 
     detailed_place = place.load_place(lang=lang)
     return InstantAnswerResult(
@@ -107,6 +108,10 @@ async def get_instant_answer(
     run more restrictive checks on its results.
     """
     normalized_query = normalize(q)
+
+    if len(normalized_query) > ia_max_query_length:
+        raise NoInstantAnswerToDisplay
+
     if normalized_query == "":
         if settings["IA_SUCCESS_ON_GENERIC_QUERIES"]:
             result = InstantAnswerResult(
@@ -149,11 +154,11 @@ async def get_instant_answer(
             )
             return build_response(result, query=q, lang=lang)
 
-        raise HTTPException(404)
+        raise NoInstantAnswerToDisplay
 
     intention = intentions[0]
     if not intention.filter.bbox:
-        raise HTTPException(404)
+        raise NoInstantAnswerToDisplay
 
     category = intention.filter.category
 
@@ -170,7 +175,7 @@ async def get_instant_answer(
 
     places = places_bbox_response.places
     if len(places) == 0:
-        raise HTTPException(404)
+        raise NoInstantAnswerToDisplay
 
     if len(places) == 1:
         place_id = places[0].id

--- a/idunn/api/urls.py
+++ b/idunn/api/urls.py
@@ -1,3 +1,5 @@
+from fastapi import Depends
+
 from .pois import get_poi
 from .places import get_place, get_place_latlon
 from .status import get_status
@@ -10,13 +12,13 @@ from ..geocoder.models import IdunnAutocomplete
 from .directions import get_directions_with_coordinates, get_directions
 from .urlsolver import follow_redirection
 from .instant_answer import get_instant_answer, InstantAnswerResponse
-
 from ..places.place import Address, Place
 from ..utils.prometheus import (
     expose_metrics,
     expose_metrics_multiprocess,
     MonitoredAPIRoute as APIRoute,
 )
+from ..utils.ban_check import check_banned_client
 
 
 def get_metric_handler(settings):
@@ -85,6 +87,7 @@ def get_api_urls(settings):
         APIRoute(
             "/instant_answer",
             get_instant_answer,
+            dependencies=[Depends(check_banned_client)],
             response_model=InstantAnswerResponse,
             responses={
                 200: {"description": "Details about place(s) to display"},

--- a/idunn/utils/ban_check.py
+++ b/idunn/utils/ban_check.py
@@ -1,0 +1,37 @@
+import logging
+from typing import Optional
+from httpx import AsyncClient
+from fastapi import Header, HTTPException
+from idunn import settings
+
+logger = logging.getLogger(__name__)
+
+if settings["BANCHECK_ENABLED"]:
+    ban_check_http = AsyncClient(
+        base_url=settings["QWANT_API_BASE_URL"],
+        timeout=float(settings["BANCHECK_TIMEOUT"]),
+    )
+else:
+    ban_check_http = None
+
+
+async def check_banned_client(x_client_hash: Optional[str] = Header(None)):
+    if ban_check_http is None:
+        return
+    if not x_client_hash:
+        return
+    try:
+        response = await ban_check_http.get(
+            "/v3/captcha/isban", params={"client_hash": x_client_hash}
+        )
+        response.raise_for_status()
+        response_data = response.json()
+        response_status = response_data.get("status")
+        if response_status != "success":
+            raise Exception(f"Got invalid status {repr(response_status)} from ban check")
+        is_client_banned = bool(response_data.get("data"))
+        if is_client_banned:
+            raise HTTPException(status_code=429)
+    except Exception as err:
+        logger.error("Failed to check client is not banned", exc_info=True)
+        raise HTTPException(status_code=503) from err

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -178,3 +178,9 @@ RECYCLING_MEASURES_MAX_AGE_IN_HOURS: 168 # 7 days (Older measures will be ignore
 ##########################
 ## Instant Answer
 IA_SUCCESS_ON_GENERIC_QUERIES: False
+
+###########################
+## Ban check, for anti-scraping purposes
+QWANT_API_BASE_URL:
+BANCHECK_ENABLED: False
+BANCHECK_TIMEOUT: "0.3" # seconds

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -177,6 +177,7 @@ RECYCLING_MEASURES_MAX_AGE_IN_HOURS: 168 # 7 days (Older measures will be ignore
 
 ##########################
 ## Instant Answer
+IA_MAX_QUERY_LENGTH: 100
 IA_SUCCESS_ON_GENERIC_QUERIES: False
 
 ###########################

--- a/tests/test_instant_answer/test_ia_api.py
+++ b/tests/test_instant_answer/test_ia_api.py
@@ -62,3 +62,9 @@ def test_ia_intention_single_result(
     assert len(places) == 1
     place = places[0]
     assert place["name"] == "Carrefour Market"
+
+
+def test_ia_query_too_long():
+    client = TestClient(app)
+    response = client.get("/v1/instant_answer", params={"q": "A" * 101})
+    assert response.status_code == 404


### PR DESCRIPTION
For instant answers only at this point:
 * Integrate "ban redis" mechanism: return 429 status code for clients found in redis
 * Limit query length (to 100 chars by default)