### PR TITLE
Instant answers: sort places by distance from intention POI point

### DIFF
--- a/idunn/places/base.py
+++ b/idunn/places/base.py
@@ -1,4 +1,5 @@
 import logging
+from geopy import Point
 
 from idunn.api.utils import Verbosity, WikidataConnector, get_geom, build_blocks
 from idunn.blocks import WikiUndefinedException, GET_WIKI_INFO
@@ -191,6 +192,10 @@ class BasePlace(dict):
 
     def get_coord(self):
         return self.get("coord")
+
+    def get_point(self):
+        coord = self.get_coord()
+        return Point(latitude=coord["lat"], longitude=coord["lon"])
 
     def get_raw_opening_hours(self):
         return self.properties.get("opening_hours")


### PR DESCRIPTION
This change is meaningful for intentions where the related `place` is a POI (without bbox).
In this case, the search bbox is defined arbitrary around this point. This did not guarantee that the nearest results would appear at the top of the list.

In this specific case, this PR suggests to sort results by distance from the reference point, for relevance purposes.