### PR TITLE
Monitoring and logging adjustments for instant answers

### DIFF
--- a/idunn/api/instant_answer.py
+++ b/idunn/api/instant_answer.py
@@ -71,19 +71,18 @@ class InstantAnswerResponse(BaseModel):
     data: InstantAnswerData
 
 
-class NoInstantAnswerToDisplay(HTTPException):
-    def __init__(self, query=None, lang=None):
-        super().__init__(status_code=404, detail="No instant answer to display")
-        if query is not None:
-            logger.info(
-                "get_instant_answer: no answer",
-                extra={
-                    "request": {
-                        "query": query,
-                        "lang": lang,
-                    }
-                },
-            )
+def no_instant_answer(query=None, lang=None):
+    if query is not None:
+        logger.info(
+            "get_instant_answer: no answer",
+            extra={
+                "request": {
+                    "query": query,
+                    "lang": lang,
+                }
+            },
+        )
+    raise HTTPException(status_code=404, detail="No instant answer to display")
 
 
 def build_response(result: InstantAnswerResult, query: str, lang: str):
@@ -111,11 +110,11 @@ def build_response(result: InstantAnswerResult, query: str, lang: str):
 def get_instant_answer_single_place(place_id: str, lang: str):
     try:
         place = place_from_id(place_id, follow_redirect=True)
-    except Exception as exc:
+    except Exception:
         logger.warning(
             "get_instant_answer: Failed to get place with id '%s'", place_id, exc_info=True
         )
-        raise NoInstantAnswerToDisplay from exc
+        return no_instant_answer()
 
     detailed_place = place.load_place(lang=lang)
     return InstantAnswerResult(
@@ -127,68 +126,9 @@ def get_instant_answer_single_place(place_id: str, lang: str):
     )
 
 
-async def get_instant_answer(
-    q: str = Query(..., title="Query string"), lang: str = Query("en", title="Language")
-):
-    """
-    Perform a query with result intended to be displayed as an instant answer
-    on *qwant.com*.
-
-    This should not be confused with "Get Places Bbox" as this endpoint will
-    run more restrictive checks on its results.
-    """
-    normalized_query = normalize(q)
-
-    if len(normalized_query) > ia_max_query_length:
-        raise NoInstantAnswerToDisplay(query=q, lang=lang)
-
-    if normalized_query == "":
-        if settings["IA_SUCCESS_ON_GENERIC_QUERIES"]:
-            result = InstantAnswerResult(
-                places=[],
-                maps_url=maps_urls.get_default_url(),
-                maps_frame_url=maps_urls.get_default_url(no_ui=True),
-            )
-            return build_response(result, query=q, lang=lang)
-        raise NoInstantAnswerToDisplay(query=q, lang=lang)
-
-    if lang in nlu_allowed_languages:
-        try:
-            intentions = await nlu_client.get_intentions(text=normalized_query, lang=lang)
-        except NluClientException:
-            intentions = []
-    else:
-        intentions = []
-
-    if not intentions:
-        bragi_response = await bragi_client.raw_autocomplete(
-            {"q": normalized_query, "lang": lang, "limit": 5}
-        )
-        geocodings = (feature["properties"]["geocoding"] for feature in bragi_response["features"])
-        geocodings = sorted(
-            (
-                (
-                    result_filter.rank_bragi_response(normalized_query, feature),
-                    feature,
-                )
-                for feature in geocodings
-                if result_filter.check_bragi_response(normalized_query, feature)
-            ),
-            key=lambda item: -item[0],  # sort by descending rank
-        )
-
-        if geocodings:
-            place_id = geocodings[0][1]["id"]
-            result = await run_in_threadpool(
-                get_instant_answer_single_place, place_id=place_id, lang=lang
-            )
-            return build_response(result, query=q, lang=lang)
-
-        raise NoInstantAnswerToDisplay(query=q, lang=lang)
-
-    intention = intentions[0]
+async def get_instant_answer_intention(intention, query: str, lang: str):
     if not intention.filter.bbox:
-        raise NoInstantAnswerToDisplay
+        return no_instant_answer(query=query, lang=lang)
 
     category = intention.filter.category
 
@@ -218,7 +158,7 @@ async def get_instant_answer(
 
     places = places_bbox_response.places
     if len(places) == 0:
-        raise NoInstantAnswerToDisplay(query=q, lang=lang)
+        return no_instant_answer(query=query, lang=lang)
 
     if len(places) == 1:
         place_id = places[0].id
@@ -238,4 +178,63 @@ async def get_instant_answer(
             maps_frame_url=maps_urls.get_places_url(intention.filter, no_ui=True),
         )
 
+    return build_response(result, query=query, lang=lang)
+
+
+async def get_instant_answer(
+    q: str = Query(..., title="Query string"), lang: str = Query("en", title="Language")
+):
+    """
+    Perform a query with result intended to be displayed as an instant answer
+    on *qwant.com*.
+
+    This should not be confused with "Get Places Bbox" as this endpoint will
+    run more restrictive checks on its results.
+    """
+    normalized_query = normalize(q)
+
+    if len(normalized_query) > ia_max_query_length:
+        return no_instant_answer(query=q, lang=lang)
+
+    if normalized_query == "":
+        if settings["IA_SUCCESS_ON_GENERIC_QUERIES"]:
+            result = InstantAnswerResult(
+                places=[],
+                maps_url=maps_urls.get_default_url(),
+                maps_frame_url=maps_urls.get_default_url(no_ui=True),
+            )
+            return build_response(result, query=q, lang=lang)
+        return no_instant_answer(query=q, lang=lang)
+
+    if lang in nlu_allowed_languages:
+        try:
+            intentions = await nlu_client.get_intentions(text=normalized_query, lang=lang)
+            if intentions:
+                return await get_instant_answer_intention(intentions[0], query=q, lang=lang)
+        except NluClientException:
+            # No intention could be interpreted from query
+            pass
+
+    # Direct geocoding query
+    bragi_response = await bragi_client.raw_autocomplete(
+        {"q": normalized_query, "lang": lang, "limit": 5}
+    )
+    geocodings = (feature["properties"]["geocoding"] for feature in bragi_response["features"])
+    geocodings = sorted(
+        (
+            (
+                result_filter.rank_bragi_response(normalized_query, feature),
+                feature,
+            )
+            for feature in geocodings
+            if result_filter.check_bragi_response(normalized_query, feature)
+        ),
+        key=lambda item: -item[0],  # sort by descending rank
+    )
+
+    if not geocodings:
+        return no_instant_answer(query=q, lang=lang)
+
+    place_id = geocodings[0][1]["id"]
+    result = await run_in_threadpool(get_instant_answer_single_place, place_id=place_id, lang=lang)
     return build_response(result, query=q, lang=lang)

--- a/idunn/utils/result_filter.py
+++ b/idunn/utils/result_filter.py
@@ -151,7 +151,7 @@ def check(
     place_type: str,
     admins: List[str] = [],
     postcodes: List[str] = [],
-) -> Optional[float]:
+) -> bool:
     query_words = words(query.lower())
     names = list(map(str.lower, names))
     admins = list(map(str.lower, admins))
@@ -168,7 +168,7 @@ def check(
 
     for q_word in query_words:
         if not any(word_matches(q_word, l_word) for l_word in full_label):
-            logger.info(
+            logger.debug(
                 "Removed `%s` from results because queried `%s` does not match the result",
                 names[0],
                 q_word,
@@ -195,7 +195,7 @@ def check(
     )
 
     if not check_coverage:
-        logger.info(
+        logger.debug(
             "Removed `%s` from results because query `%s` is not accurate enough",
             names[0],
             query,


### PR DESCRIPTION
Each commit can be reviewed independently

- count and time all requests in Prometheus metrics, including `HTTPException` with error status codes, and other exceptions
- update "result_filter" log level
- add log messages about  instant answer responses, to be able to analyze the proportion of valid responses based on these logs