### PR TITLE
pagesjaunes: build affiliation links

### DIFF
--- a/idunn/places/pj_poi.py
+++ b/idunn/places/pj_poi.py
@@ -395,14 +395,7 @@ class PjApiPOI(BasePlace):
         return PoiSource.PAGESJAUNES
 
     def get_source_url(self):
-        return next(
-            (
-                ins.urls.merchant_url
-                for ins in self.data.inscriptions
-                if ins.urls and ins.urls.merchant_url
-            ),
-            None,
-        )
+        return f"https://www.pagesjaunes.fr/pros/{self.data.merchant_id}"
 
     def get_raw_grades(self):
         grade_count = sum(
@@ -425,11 +418,4 @@ class PjApiPOI(BasePlace):
         }
 
     def get_reviews_url(self):
-        return next(
-            (
-                ins.urls.reviews_url
-                for ins in self.data.inscriptions
-                if ins.urls and ins.urls.reviews_url
-            ),
-            None,
-        )
+        return self.get_source_url() + "#ancreBlocAvis"

--- a/tests/fixtures/pj/musee_picasso.json
+++ b/tests/fixtures/pj/musee_picasso.json
@@ -69,7 +69,7 @@
       "addPhoto": "https:/[AJOUTER_PHOTO]",
       "addReview": "https://[AJOUTER_AVIS]",
       "view": "https://[FD]",
-      "viewReviews": "https://[VOIR_TOUS_AVIS]"
+      "viewReviews": "https://www.pagesjaunes.fr/pros/05360257#ancreBlocAvis"
     },
     "WheelchairAccessible": true,
     "ContactInfos": {

--- a/tests/test_pj_poi.py
+++ b/tests/test_pj_poi.py
@@ -95,7 +95,7 @@ def test_pj_place(enable_pj_source):
     assert blocks[5]["type"] == "grades"
     assert blocks[5]["total_grades_count"] == 8
     assert blocks[5]["global_grade"] == 4.0
-    assert blocks[5]["url"] == "https://[VOIR_TOUS_AVIS]"
+    assert blocks[5]["url"] == "https://www.pagesjaunes.fr/pros/05360257#ancreBlocAvis"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Build affiliation links instead of using links provided by the API to avoid slight privacy concerns.

The most naive approach would be to provide `https://www.pagesjaunes.fr/pros/{merchant_id}#blocAvis` ~~but we still want to allow some metrics so I kept `https://www.pagesjaunes.fr/partenaire?id={merchant_id}&component=review&action=view&xtor=AD-350-[QWANT]-[CONTRIBUTIF]-[VOIR_TOUS_AVIS]` from production.~~