### PR TITLE
nlu_client: use classifier weights to ignore ambiguous results

### DIFF
--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -136,6 +136,11 @@ NLU_TAGGER_LOWERCASE: True
 NLU_CLASSIFIER_URL:
 NLU_CLASSIFIER_DOMAIN: "poi"
 
+# Classifier parameters
+NLU_CLASSIFIER_MIN_UNK_IGNORED: 0.1 # Minimum value for "unk" to consider query as unclassified
+NLU_CLASSIFIER_CATEGORY_MIN_WEIGHT: 0.15 # Minimum weight required for a category
+NLU_CLASSIFIER_MAX_WEIGHT_RATIO: 0.6 # Maximal ratio with the second best result
+
 NLU_BREAKER_TIMEOUT: 120 # timeout period in seconds
 NLU_BREAKER_MAXFAIL: 5 # consecutive failures before breaking
 

--- a/tests/fixtures/autocomplete/classif_pharmacy.json
+++ b/tests/fixtures/autocomplete/classif_pharmacy.json
@@ -3,8 +3,16 @@
     "domain": "poi",
     "intention": [
         [
+            1.0000003385357559e-05,
+            "health_other"
+        ],
+        [
             1.0000100135803223,
             "pharmacy"
+        ],
+        [
+            1.0000003385357559e-05,
+            "place_of_worship"
         ]
     ],
     "text": "pharmacy",

--- a/tests/test_nlu_client.py
+++ b/tests/test_nlu_client.py
@@ -1,0 +1,11 @@
+from idunn.geocoder.nlu_client import NLU_Helper
+
+
+def test_classifier_handle_response():
+    cat_for = NLU_Helper.nlu_classifier_handle_response
+    assert cat_for({"intention": []}) is None
+    assert cat_for({"intention": [(0.10, "restaurant")]}) is None
+    assert cat_for({"intention": [(0.99, "restaurant")]}).value == "restaurant"
+    assert cat_for({"intention": [(0.99, "restaurant"), (0.90, "pharmacy")]}) is None
+    assert cat_for({"intention": [(0.99, "restaurant"), (0.20, "unk")]}) is None
+    assert cat_for({"intention": [(0.99, "restaurant"), (0.01, "unk")]}).value == "restaurant"


### PR DESCRIPTION
Make use of the provided weights from the classifier:

 - check that the special category `unk` (understand "unclassified") is missing or negligible
 - check that the result has a big weight
 - check that there is not several categories with a big weight

This is based on [this function](https://git.qwant.ninja/r.dupre/scripts/-/blob/master/util/nlu.py#L55-87) that I had tested [here](https://git.qwant.ninja/r.dupre/scripts/-/blob/master/check_ia_classification.py). The default settings were chosen by testing many combinations through [this script](https://git.qwant.ninja/r.dupre/scripts/-/blob/master/classif-params/src/main.rs) (which actually seems overkill, arbitrary values would have probably worked fine).