### PR TITLE
ia: Return status 204 instead of 404 when no instant answer to display

### DIFF
--- a/idunn/api/instant_answer.py
+++ b/idunn/api/instant_answer.py
@@ -1,6 +1,6 @@
 import logging
-from fastapi import HTTPException, Query
-from fastapi.responses import ORJSONResponse
+from fastapi import Query
+from fastapi.responses import ORJSONResponse, Response
 from fastapi.concurrency import run_in_threadpool
 from typing import Optional, List, Tuple
 from pydantic import BaseModel, Field, validator, HttpUrl
@@ -85,7 +85,7 @@ def no_instant_answer(query=None, lang=None, region=None):
                 }
             },
         )
-    raise HTTPException(status_code=404, detail="No instant answer to display")
+    return Response(status_code=204)
 
 
 def build_response(result: InstantAnswerResult, query: str, lang: str):

--- a/idunn/api/urls.py
+++ b/idunn/api/urls.py
@@ -91,7 +91,7 @@ def get_api_urls(settings):
             response_model=InstantAnswerResponse,
             responses={
                 200: {"description": "Details about place(s) to display"},
-                404: {"description": "No instant answer to display"},
+                204: {"description": "No instant answer to display"},
             },
         ),
     ]

--- a/tests/test_instant_answer/test_ia_api.py
+++ b/tests/test_instant_answer/test_ia_api.py
@@ -97,4 +97,4 @@ def test_ia_intention_single_result(
 def test_ia_query_too_long():
     client = TestClient(app)
     response = client.get("/v1/instant_answer", params={"q": "A" * 101})
-    assert response.status_code == 404
+    assert response.status_code == 204


### PR DESCRIPTION
To disambiguate between absence of results and actual errors.