### PR TITLE
add endpoint `search`

### DIFF
--- a/idunn/api/geocoder.py
+++ b/idunn/api/geocoder.py
@@ -82,4 +82,4 @@ async def get_autocomplete(
                 )
             )
         autocomplete_response["intentions"] = intentions
-    return autocomplete_response
+    return IdunnAutocomplete(**autocomplete_response)

--- a/idunn/api/instant_answer.py
+++ b/idunn/api/instant_answer.py
@@ -181,7 +181,7 @@ async def get_instant_answer_intention(intention, query: str, lang: str):
             maps_frame_url=maps_urls.get_places_url(intention.filter, no_ui=True),
         )
 
-    return result
+    return build_response(result, query=query, lang=lang)
 
 
 async def get_instant_answer(
@@ -223,11 +223,7 @@ async def get_instant_answer(
                 normalized_query, lang, extra_geocoder_params
             )
             if intentions:
-                return build_response(
-                    await get_instant_answer_intention(intentions[0], query=q, lang=lang),
-                    q,
-                    lang,
-                )
+                return await get_instant_answer_intention(intentions[0], query=q, lang=lang)
         except NluClientException:
             # No intention could be interpreted from query
             pass

--- a/idunn/api/instant_answer.py
+++ b/idunn/api/instant_answer.py
@@ -181,7 +181,7 @@ async def get_instant_answer_intention(intention, query: str, lang: str):
             maps_frame_url=maps_urls.get_places_url(intention.filter, no_ui=True),
         )
 
-    return build_response(result, query=query, lang=lang)
+    return result
 
 
 async def get_instant_answer(
@@ -223,7 +223,11 @@ async def get_instant_answer(
                 normalized_query, lang, extra_geocoder_params
             )
             if intentions:
-                return await get_instant_answer_intention(intentions[0], query=q, lang=lang)
+                return build_response(
+                    await get_instant_answer_intention(intentions[0], query=q, lang=lang),
+                    q,
+                    lang,
+                )
         except NluClientException:
             # No intention could be interpreted from query
             pass

--- a/idunn/api/search.py
+++ b/idunn/api/search.py
@@ -1,0 +1,115 @@
+import logging
+from fastapi import Depends, HTTPException
+from fastapi.concurrency import run_in_threadpool
+from typing import Optional
+from pydantic import BaseModel, Field
+
+from idunn import settings
+from idunn.api.places_list import PlacesBboxResponse
+from idunn.geocoder.bragi_client import bragi_client
+from idunn.geocoder.models.geocodejson import Intention
+from idunn.geocoder.nlu_client import nlu_client, NluClientException
+from idunn.places import place_from_id, Place
+from idunn.utils import result_filter
+from idunn.instant_answer import normalize
+from .instant_answer import get_instant_answer_intention
+from ..geocoder.models import QueryParams, IdunnAutocomplete
+
+logger = logging.getLogger(__name__)
+
+nlu_allowed_languages = settings["NLU_ALLOWED_LANGUAGES"].split(",")
+
+
+class SearchResult(BaseModel):
+    """Exactly one of the fields `places` or `place` are defined."""
+
+    bbox_places: Optional[PlacesBboxResponse] = Field(
+        None, description="A list of places as results."
+    )
+    place: Optional[Place] = Field(None, description="A list of places as results.")
+
+
+def no_search_result(query=None, lang=None):
+    if query is not None:
+        logger.info(
+            "search: no result",
+            extra={
+                "request": {
+                    "query": query,
+                    "lang": lang,
+                }
+            },
+        )
+    return SearchResult()
+
+
+async def search_intention(intention: Intention, query: str, lang: str) -> SearchResult:
+    try:
+        ia_result = await get_instant_answer_intention(intention, query, lang)
+    except HTTPException(status_code=404):
+        return SearchResult()
+
+    if len(ia_result.places) == 1:
+        result = SearchResult(place=ia_result.places[0])
+    else:
+        result = SearchResult(
+            bbox_places=PlacesBboxResponse(
+                places=ia_result.places,
+                source=ia_result.source,
+                bbox=ia_result.intention_bbox,
+                bbox_extended=False,
+            ),
+        )
+
+    return result
+
+
+def search_single_place(place_id: str, lang: str):
+    try:
+        place = place_from_id(place_id, follow_redirect=True)
+    except Exception:
+        logger.warning("search: Failed to get place with id '%s'", place_id, exc_info=True)
+        return no_search_result()
+
+    detailed_place = place.load_place(lang=lang)
+    return SearchResult(place=detailed_place)
+
+
+async def search(query: QueryParams = Depends(QueryParams)) -> IdunnAutocomplete:
+    """
+    Perform a query which is intended to display a relevant result directly (as
+    opposed to `autocomplete` which gives a list of plausible results).
+
+    Similarly to `instant_answer`, the result will need some quality checks.
+    """
+    query.q = normalize(query.q)
+
+    if query.lang in nlu_allowed_languages:
+        try:
+            intentions = await nlu_client.get_intentions(text=query.q, lang=query.lang)
+            if intentions:
+                return await search_intention(intentions[0], query=query.q, lang=query.lang)
+        except NluClientException:
+            # No intention could be interpreted from query
+            pass
+
+    # Direct geocoding query
+    bragi_response = await bragi_client.raw_autocomplete(
+        {"q": query.q, "lang": query.lang, "limit": 5}
+    )
+    geocodings = (feature["properties"]["geocoding"] for feature in bragi_response["features"])
+    geocodings = sorted(
+        (
+            (result_filter.rank_bragi_response(query.q, feature), feature)
+            for feature in geocodings
+            if result_filter.check_bragi_response(query.q, feature)
+        ),
+        key=lambda item: -item[0],  # sort by descending rank
+    )
+
+    if not geocodings:
+        return no_search_result(query=query.q, lang=query.lang)
+
+    place_id = geocodings[0][1]["id"]
+    result = await run_in_threadpool(search_single_place, place_id=place_id, lang=query.lang)
+    return result

--- a/idunn/api/search.py
+++ b/idunn/api/search.py
@@ -4,7 +4,6 @@ from fastapi import Depends
 from idunn import settings
 from idunn.geocoder.bragi_client import bragi_client
 from idunn.geocoder.nlu_client import nlu_client, NluClientException
-from idunn.places import place_from_id
 from idunn.utils import result_filter
 from idunn.instant_answer import normalize
 from ..geocoder.models import QueryParams, IdunnAutocomplete
@@ -26,17 +25,6 @@ def no_search_result(query=None, lang=None):
             },
         )
     return IdunnAutocomplete()
-
-
-def search_single_place(place_id: str, lang: str):
-    try:
-        place = place_from_id(place_id, follow_redirect=True)
-    except Exception:
-        logger.warning("search: Failed to get place with id '%s'", place_id, exc_info=True)
-        return no_search_result()
-
-    detailed_place = place.load_place(lang=lang)
-    return IdunnAutocomplete(features=[detailed_place])
 
 
 async def search(query: QueryParams = Depends(QueryParams)) -> IdunnAutocomplete:

--- a/idunn/api/search.py
+++ b/idunn/api/search.py
@@ -38,7 +38,7 @@ async def search(
     """
     query.q = normalize(query.q)
 
-    if query.lang in nlu_allowed_languages:
+    if query.nlu and query.lang in nlu_allowed_languages:
         try:
             intentions = await nlu_client.get_intentions(text=query.q, lang=query.lang)
             if intentions:

--- a/idunn/api/search.py
+++ b/idunn/api/search.py
@@ -1,15 +1,12 @@
 import logging
-from fastapi import Depends, HTTPException
+from fastapi import Depends
 
 from idunn import settings
-from idunn.api.places_list import PlacesBboxResponse
 from idunn.geocoder.bragi_client import bragi_client
-from idunn.geocoder.models.geocodejson import Intention
 from idunn.geocoder.nlu_client import nlu_client, NluClientException
 from idunn.places import place_from_id
 from idunn.utils import result_filter
 from idunn.instant_answer import normalize
-from .instant_answer import get_instant_answer_intention
 from ..geocoder.models import QueryParams, IdunnAutocomplete
 
 logger = logging.getLogger(__name__)
@@ -29,29 +26,6 @@ def no_search_result(query=None, lang=None):
             },
         )
     return IdunnAutocomplete()
-
-
-async def search_intention(intention: Intention, query: str, lang: str) -> IdunnAutocomplete:
-    try:
-        ia_result = await get_instant_answer_intention(intention, query, lang)
-    except HTTPException(status_code=404):
-        return IdunnAutocomplete()
-
-    if len(ia_result.places) == 1:
-        result = IdunnAutocomplete(place=ia_result.places[0])
-    else:
-        result = IdunnAutocomplete(
-            bbox_places=[
-                PlacesBboxResponse(
-                    places=ia_result.places,
-                    source=ia_result.source,
-                    bbox=ia_result.intention_bbox,
-                    bbox_extended=False,
-                )
-            ],
-        )
-
-    return result
 
 
 def search_single_place(place_id: str, lang: str):

--- a/idunn/api/search.py
+++ b/idunn/api/search.py
@@ -2,8 +2,7 @@ import logging
 from fastapi import Body, Depends
 
 from idunn import settings
-from idunn.geocoder.bragi_client import bragi_client
-from idunn.geocoder.nlu_client import nlu_client, NluClientException
+from idunn.api.geocoder import get_autocomplete
 from idunn.utils import result_filter
 from idunn.instant_answer import normalize
 from ..geocoder.models import ExtraParams, QueryParams, IdunnAutocomplete
@@ -11,20 +10,6 @@ from ..geocoder.models import ExtraParams, QueryParams, IdunnAutocomplete
 logger = logging.getLogger(__name__)
 
 nlu_allowed_languages = settings["NLU_ALLOWED_LANGUAGES"].split(",")
-
-
-def no_search_result(query=None, lang=None):
-    if query is not None:
-        logger.info(
-            "search: no result",
-            extra={
-                "request": {
-                    "query": query,
-                    "lang": lang,
-                }
-            },
-        )
-    return IdunnAutocomplete()
 
 
 async def search(
@@ -36,30 +21,31 @@ async def search(
 
     Similarly to `instant_answer`, the result will need some quality checks.
     """
+    # Fetch autocomplete results which will be filtered
     query.q = normalize(query.q)
+    response = await get_autocomplete(query, extra)
 
-    if query.nlu and query.lang in nlu_allowed_languages:
-        try:
-            intentions = await nlu_client.get_intentions(text=query.q, lang=query.lang)
-            if intentions:
-                return IdunnAutocomplete(intentions=intentions)
-        except NluClientException:
-            # No intention could be interpreted from query
-            pass
+    # When an intention is detected, it takes over on geocoding features
+    if response.intentions:
+        response.features = []
+        return response
 
-    # Direct geocoding query
-    bragi_response = await bragi_client.autocomplete(query, extra)
-    features = sorted(
-        (
-            (result_filter.rank_bragi_response(query.q, geocoding), feature)
-            for feature in bragi_response["features"]
-            for geocoding in [feature["properties"]["geocoding"]]
-            if result_filter.check_bragi_response(query.q, geocoding)
-        ),
-        key=lambda item: -item[0],  # sort by descending rank
+    # Filter relevent features
+    feasible_features = filter(
+        lambda ft: result_filter.check_bragi_response(query.q, ft.properties.geocoding.dict()),
+        response.features,
     )
 
-    if not features:
-        return no_search_result(query=query.q, lang=query.lang)
+    # Pick most relevant feature, if any
+    best_feature = max(
+        feasible_features,
+        default=None,
+        key=lambda ft: result_filter.rank_bragi_response(query.q, ft.properties.geocoding.dict()),
+    )
 
-    return IdunnAutocomplete(features=[features[0][1]])
+    if best_feature:
+        response.features = [best_feature]
+    else:
+        response.features = []
+
+    return response

--- a/idunn/api/urls.py
+++ b/idunn/api/urls.py
@@ -78,7 +78,9 @@ def get_api_urls(settings):
         APIRoute(
             "/search",
             search,
+            methods=["GET", "POST"],
             response_model=IdunnAutocomplete,
+            response_model_exclude_unset=True,
         ),
         # Solve URLs
         APIRoute(

--- a/idunn/api/urls.py
+++ b/idunn/api/urls.py
@@ -13,7 +13,7 @@ from .directions import get_directions_with_coordinates, get_directions
 from .urlsolver import follow_redirection
 from .instant_answer import get_instant_answer, InstantAnswerResponse
 from ..places.place import Address, Place
-from .search import search, SearchResult
+from .search import search
 from ..utils.prometheus import (
     expose_metrics,
     expose_metrics_multiprocess,
@@ -78,7 +78,7 @@ def get_api_urls(settings):
         APIRoute(
             "/search",
             search,
-            response_model=SearchResult,
+            response_model=IdunnAutocomplete,
         ),
         # Solve URLs
         APIRoute(

--- a/idunn/api/urls.py
+++ b/idunn/api/urls.py
@@ -13,6 +13,7 @@ from .directions import get_directions_with_coordinates, get_directions
 from .urlsolver import follow_redirection
 from .instant_answer import get_instant_answer, InstantAnswerResponse
 from ..places.place import Address, Place
+from .search import search, SearchResult
 from ..utils.prometheus import (
     expose_metrics,
     expose_metrics_multiprocess,
@@ -73,6 +74,11 @@ def get_api_urls(settings):
             methods=["GET", "POST"],
             response_model=IdunnAutocomplete,
             response_model_exclude_unset=True,
+        ),
+        APIRoute(
+            "/search",
+            search,
+            response_model=SearchResult,
         ),
         # Solve URLs
         APIRoute(

--- a/idunn/geocoder/models/geocodejson.py
+++ b/idunn/geocoder/models/geocodejson.py
@@ -98,7 +98,7 @@ class GeocodingPlace(BaseModel):
 
     # The following fields are part of the GeocodeJson specification but are
     # currently disabled in Bragi:
-    #  https://github.com/CanalTP/mimirsbrunn/blob/master/libs/bragi/src/model.rs#L194-L199
+    # https://github.com/CanalTP/mimirsbrunn/blob/master/libs/bragi/src/model.rs#L194-L199
     #
     # accuracy: Optional[PositiveInt]
     # district: Optional[str]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,45 @@
+import pytest
+from fastapi.testclient import TestClient
+from app import app
+
+from .fixtures.autocomplete import (
+    mock_autocomplete_get,
+    mock_NLU_with_city,
+    mock_NLU_with_brand_and_city,
+    mock_bragi_carrefour_in_bbox,
+)
+
+
+def test_search_paris(mock_autocomplete_get, mock_NLU_with_city):
+    client = TestClient(app)
+    response = client.get("/v1/search", params={"q": "paris", "lang": "fr"})
+    assert response.status_code == 200
+    response_json = response.json()
+    place = response_json["place"]
+    assert place["name"] == "Paris"
+
+
+def test_search_intention_full_text(
+    mock_NLU_with_brand_and_city, mock_autocomplete_get, mock_bragi_carrefour_in_bbox
+):
+    client = TestClient(app)
+    response = client.get("/v1/search", params={"q": "carrefour à paris", "lang": "fr"})
+    assert response.status_code == 200
+    response_json = response.json()
+    print(response_json)
+    places = response_json["bbox_places"]["places"]
+    assert len(places) == 5
+    place = places[0]
+    assert place["name"] == "Carrefour Market"
+
+
+@pytest.mark.parametrize("mock_bragi_carrefour_in_bbox", [{"limit": 1}], indirect=True)
+def test_search_intention_single_result(
+    mock_NLU_with_brand_and_city, mock_autocomplete_get, mock_bragi_carrefour_in_bbox
+):
+    client = TestClient(app)
+    response = client.get("/v1/search", params={"q": "carrefour à paris", "lang": "fr"})
+    assert response.status_code == 200
+    response_json = response.json()
+    place = response_json["place"]
+    assert place["name"] == "Carrefour Market"

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -6,13 +6,12 @@ from .fixtures.autocomplete import (
     mock_autocomplete_get,
     mock_NLU_with_city,
     mock_NLU_with_brand_and_city,
-    mock_bragi_carrefour_in_bbox,
 )
 
 
 def test_search_paris(mock_autocomplete_get, mock_NLU_with_city):
     client = TestClient(app)
-    response = client.get("/v1/search", params={"q": "paris", "lang": "fr"})
+    response = client.get("/v1/search", params={"q": "paris", "lang": "fr", "nlu": True})
     assert response.status_code == 200
     response_json = response.json()
     place = response_json["features"][0]["properties"]["geocoding"]
@@ -21,7 +20,7 @@ def test_search_paris(mock_autocomplete_get, mock_NLU_with_city):
 
 def test_search_intention_full_text(mock_NLU_with_brand_and_city, mock_autocomplete_get):
     client = TestClient(app)
-    response = client.get("/v1/search", params={"q": "auchan à paris", "lang": "fr"})
+    response = client.get("/v1/search", params={"q": "auchan à paris", "lang": "fr", "nlu": True})
     assert response.status_code == 200
     response_json = response.json()
     intention = response_json["intentions"][0]["filter"]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -15,31 +15,15 @@ def test_search_paris(mock_autocomplete_get, mock_NLU_with_city):
     response = client.get("/v1/search", params={"q": "paris", "lang": "fr"})
     assert response.status_code == 200
     response_json = response.json()
-    place = response_json["place"]
+    place = response_json["features"][0]["properties"]["geocoding"]
     assert place["name"] == "Paris"
 
 
-def test_search_intention_full_text(
-    mock_NLU_with_brand_and_city, mock_autocomplete_get, mock_bragi_carrefour_in_bbox
-):
+def test_search_intention_full_text(mock_NLU_with_brand_and_city, mock_autocomplete_get):
     client = TestClient(app)
-    response = client.get("/v1/search", params={"q": "carrefour à paris", "lang": "fr"})
+    response = client.get("/v1/search", params={"q": "auchan à paris", "lang": "fr"})
     assert response.status_code == 200
     response_json = response.json()
-    print(response_json)
-    places = response_json["bbox_places"]["places"]
-    assert len(places) == 5
-    place = places[0]
-    assert place["name"] == "Carrefour Market"
-
-
-@pytest.mark.parametrize("mock_bragi_carrefour_in_bbox", [{"limit": 1}], indirect=True)
-def test_search_intention_single_result(
-    mock_NLU_with_brand_and_city, mock_autocomplete_get, mock_bragi_carrefour_in_bbox
-):
-    client = TestClient(app)
-    response = client.get("/v1/search", params={"q": "carrefour à paris", "lang": "fr"})
-    assert response.status_code == 200
-    response_json = response.json()
-    place = response_json["place"]
-    assert place["name"] == "Carrefour Market"
+    intention = response_json["intentions"][0]["filter"]
+    assert intention["q"] == "auchan"
+    assert intention["bbox"] is not None


### PR DESCRIPTION
This mostly reuses code from `instant_answer` but I tried to change the API a bit to be more consistent with what we usually use internally between erdapfel and Idunn:

 - the answer format is simpler, either consisting of the same format as `get_place` (through key `place`) or the format of `get_bbox_places` (through key `bbox_places`)
 - we don't usually raise error codes 404 when we have an empty geocoder result, I tried to stick with this by returning an empty result

The only slight behavior change is that there is no truncating of the input query, maybe we should add a global parameter for this? I've also thought about skipping normalization since it would seem weird to "ignore or change part of what is in the search bar" but this seems like a free potential improvement of results?

Part of the logs may be weird with the current state of the branch, I'm still thinking there may be some global pattern that could be built since fetching the context from the logger is a common issue we have (eg. how we build extra infos in `nlu_client` or in this case understanding what endpoint is currently being used).