### PR TITLE
`search`: more permissive filters

### DIFF
--- a/idunn/api/geocoder.py
+++ b/idunn/api/geocoder.py
@@ -6,9 +6,10 @@ from ..geocoder.nlu_client import nlu_client, NluClientException
 from ..geocoder.models import QueryParams, ExtraParams, IdunnAutocomplete
 
 from idunn import settings
-from idunn.utils import result_filter
+from idunn.utils.result_filter import ResultFilter
 
 logger = logging.getLogger(__name__)
+result_filter = ResultFilter()
 
 nlu_allowed_languages = settings["NLU_ALLOWED_LANGUAGES"].split(",")
 autocomplete_nlu_shadow_enabled = settings["AUTOCOMPLETE_NLU_SHADOW_ENABLED"]

--- a/idunn/api/instant_answer.py
+++ b/idunn/api/instant_answer.py
@@ -12,13 +12,15 @@ from idunn.geocoder.bragi_client import bragi_client
 from idunn.geocoder.models import QueryParams
 from idunn.places import place_from_id, Place
 from idunn.api.places_list import get_places_bbox_impl, PlacesQueryParam
-from idunn.utils import maps_urls, result_filter
+from idunn.utils import maps_urls
 from idunn.utils.regions import get_region_lonlat
+from idunn.utils.result_filter import ResultFilter
 from idunn.instant_answer import normalize
 from .constants import PoiSource
 from .utils import Verbosity
 
 logger = logging.getLogger(__name__)
+result_filter = ResultFilter()
 
 nlu_allowed_languages = settings["NLU_ALLOWED_LANGUAGES"].split(",")
 ia_max_query_length = int(settings["IA_MAX_QUERY_LENGTH"])

--- a/idunn/api/search.py
+++ b/idunn/api/search.py
@@ -4,10 +4,12 @@ from fastapi import Body, Depends
 from idunn import settings
 from idunn.api.geocoder import get_autocomplete
 from idunn.utils import result_filter
+from idunn.utils.result_filter import ResultFilter
 from idunn.instant_answer import normalize
 from ..geocoder.models import ExtraParams, QueryParams, IdunnAutocomplete
 
 logger = logging.getLogger(__name__)
+result_filter = ResultFilter(match_word_prefix=True, min_matching_words=3)
 
 nlu_allowed_languages = settings["NLU_ALLOWED_LANGUAGES"].split(",")
 

--- a/idunn/geocoder/nlu_client.py
+++ b/idunn/geocoder/nlu_client.py
@@ -10,12 +10,13 @@ from idunn.api.utils import Category
 from idunn.geocoder.models.params import QueryParams as GeocoderParams
 from idunn import settings
 from idunn.utils.circuit_breaker import IdunnCircuitBreaker
-from idunn.utils import result_filter
+from idunn.utils.result_filter import ResultFilter
 
 from .models.geocodejson import Intention
 from .bragi_client import bragi_client
 
 logger = logging.getLogger(__name__)
+result_filter = ResultFilter()
 
 DEFAULT_BBOX_WIDTH = 0.02
 DEFAULT_BBOX_HEIGHT = 0.01

--- a/idunn/utils/result_filter.py
+++ b/idunn/utils/result_filter.py
@@ -10,273 +10,309 @@ from jellyfish import damerau_levenshtein_distance
 logger = logging.getLogger(__name__)
 
 
-# Typical suffixes found after numbers such as "4bis", "4th", ...
-NUM_SUFFIXES = ["bis", "ter", "quad", "e", "è", "eme", "ème", "er", "st", "nd", "rd", "th"]
+class ResultFilter:
+    # Typical suffixes found after numbers such as "4bis", "4th", ...
+    NUM_SUFFIXES = ["bis", "ter", "quad", "e", "è", "eme", "ème", "er", "st", "nd", "rd", "th"]
 
-# Abrevation typicaly found in places, addresses, ...
-ABREVIATIONS = {
-    "av": "avenue",
-    "bd": "boulevard",
-    "bld": "boulevard",
-    "bvd": "boulevard",
-    "rle": "ruelle",
-    "r": "rue",
-    "rte": "route",
-    "ste": "sainte",
-    "st": "saint",
-}
+    # Abrevation typicaly found in places, addresses, ...
+    ABREVIATIONS = {
+        "av": "avenue",
+        "bd": "boulevard",
+        "bld": "boulevard",
+        "bvd": "boulevard",
+        "rle": "ruelle",
+        "r": "rue",
+        "rte": "route",
+        "ste": "sainte",
+        "st": "saint",
+    }
 
-# Regex recognizing any word separators
-WORD_SEPARATORS = re.compile("|".join([" ", "-", ",", ";", "\\.", "'"]))
+    # Regex recognizing any word separators
+    WORD_SEPARATORS = re.compile("|".join([" ", "-", ",", ";", "\\.", "'"]))
 
+    def __init__(
+        self,
+        match_word_prefix: bool = False,  # words in the query can match as prefix in the result
+        min_matching_words: Optional[int] = None,  # number of words that must match from the query
+    ):
+        """
+        Setup a filter on search results.
+          - match_word_prefix: allow words in the query to match if they are
+            only prefix of a word in the result.
+          - min_matching_words: minimum number of words of the query that must
+            match a word in the result.
+        """
+        self.match_word_prefix = match_word_prefix
+        self.min_matching_words = min_matching_words
 
-def words(text):
-    """
-    Split words into a list.
+    @classmethod
+    def words(cls, text):
+        """
+        Split words into a list.
 
-    >>> words("17, rue jaune ; Levallois-Peret")
-    ['17', 'rue', 'jaune', 'Levallois', 'Peret']
-    """
-    return [word for word in WORD_SEPARATORS.split(text) if word]
+        >>> filter = ResultFilter()
+        >>> filter.words("17, rue jaune ; Levallois-Peret")
+        ['17', 'rue', 'jaune', 'Levallois', 'Peret']
+        """
+        return [word for word in cls.WORD_SEPARATORS.split(text) if word]
 
+    @classmethod
+    def word_as_number(cls, word):
+        """
+        Attempt to intepret the word as a number, potentialy triming a suffix.
 
-def word_as_number(word):
-    """
-    Attempt to intepret the word as a number, potentialy triming a suffix.
+        >>> filter = ResultFilter()
+        >>> filter.word_as_number("17")
+        '17'
+        >>> filter.word_as_number("17bis")
+        '17'
+        >>> assert filter.word_as_number("17rue") is None
+        """
+        if word.isnumeric():
+            return word
 
-    >>> word_as_number("17")
-    '17'
-    >>> word_as_number("17bis")
-    '17'
-    >>> assert word_as_number("17rue") is None
-    """
-    if word.isnumeric():
-        return word
+        for suffix in cls.NUM_SUFFIXES:
+            if word.endswith(suffix):
+                prefix = word[: -len(suffix)]
 
-    for suffix in NUM_SUFFIXES:
-        if word.endswith(suffix):
-            prefix = word[: -len(suffix)]
+                if prefix.isnumeric():
+                    return prefix
 
-            if prefix.isnumeric():
-                return prefix
+        return None
 
-    return None
+    @classmethod
+    def word_matches_abreviation(cls, word_1, word_2):
+        """
+        Check if a word is the abreviation of the other.
 
+        >>> filter = ResultFilter()
+        >>> assert filter.word_matches_abreviation("bd", "boulevard")
+        >>> assert filter.word_matches_abreviation("avenue", "av")
+        >>> assert not filter.word_matches_abreviation("av", "bd")
+        """
+        return cls.ABREVIATIONS.get(word_1) == word_2 or cls.ABREVIATIONS.get(word_2) == word_1
 
-def word_matches_abreviation(word_1, word_2):
-    """
-    Check if a word is the abreviation of the other.
+    @lru_cache(10000)
+    def word_matches(self, query_word, label_word):
+        """
+        Check if two words match with an high degree of confidence.
 
-    >>> assert word_matches_abreviation("bd", "boulevard")
-    >>> assert word_matches_abreviation("avenue", "av")
-    >>> assert not word_matches_abreviation("av", "bd")
-    """
-    return ABREVIATIONS.get(word_1) == word_2 or ABREVIATIONS.get(word_2) == word_1
+        A single spelling mistake is allowed, defined as either a wrong letter
+        (insertion, deletion or replaced) or the inversion of two consecutive
+        letters. If an accent is defined in the query, then it must appear in
+        the result (or it will count as a spelling mistake). Abreviations are
+        supported as defined in word_matches_abreviation.
 
+        Numbers have a special treatment: if word from the query is a number
+        (without potential suffix), then it must exactly match the word from
+        the result (a number, potentialy with suffix removed).
 
-@lru_cache(10000)
-def word_matches(query_word, label_word):
-    """
-    Check if two words match with an high degree of confidence.
+        >>> filter = ResultFilter()
+        >>> assert filter.word_matches("42ter", "42")
+        >>> assert filter.word_matches("42ter", "42bis")
+        >>> assert not filter.word_matches("321", "322")
+        >>> assert not filter.word_matches("5", "u")
+        >>> assert not filter.word_matches("u", "5")
 
-    A single spelling mistake is allowed, defined as either a wrong letter
-    (insertion, deletion or replaced) or the inversion of two consecutive
-    letters. If an accent is defined in the query, then it must appear in
-    the result (or it will count as a spelling mistake). Abreviations are
-    supported as defined in word_matches_abreviation.
+        >>> assert filter.word_matches("eiffel", "ieffel")
+        >>> assert not filter.word_matches("eiffel", "ifefel")
+        >>> assert filter.word_matches("eveque", "évêque")
+        >>> assert not filter.word_matches("évêque", "eveque")
 
-    Numbers have a special treatment: if word from the query is a number
-    (without potential suffix), then it must exactly match the word from
-    the result (a number, potentialy with suffix removed).
+        >>> assert filter.word_matches("bd", "boulevard")
+        >>> assert not filter.word_matches("la", "da")
+        """
+        query_word_as_num = self.word_as_number(query_word)
+        label_word_as_num = self.word_as_number(label_word)
 
-    >>> assert word_matches("42ter", "42")
-    >>> assert word_matches("42ter", "42bis")
-    >>> assert not word_matches("321", "322")
-    >>> assert not word_matches("5", "u")
-    >>> assert not word_matches("u", "5")
+        if query_word_as_num is not None or label_word_as_num is not None:
+            return query_word_as_num == label_word_as_num
 
-    >>> assert word_matches("eiffel", "ieffel")
-    >>> assert not word_matches("eiffel", "ifefel")
-    >>> assert word_matches("eveque", "évêque")
-    >>> assert not word_matches("évêque", "eveque")
+        # The label can be matched with or without accent
+        label_variants = {label_word, unidecode(label_word)}
 
-    >>> assert word_matches("bd", "boulevard")
-    >>> assert not word_matches("la", "da")
-    """
-    query_word_as_num = word_as_number(query_word)
-    label_word_as_num = word_as_number(label_word)
-
-    if query_word_as_num is not None or label_word_as_num is not None:
-        return query_word_as_num == label_word_as_num
-
-    # The label can be matched with or without accent
-    label_variants = {label_word, unidecode(label_word)}
-
-    return (
-        # This first check is redundant with the second one but is less expensive to compute
-        any(query_word == s for s in label_variants)
-        or any(
-            damerau_levenshtein_distance(query_word, s) <= 1 for s in label_variants if len(s) > 2
+        return (
+            # This first check is redundant with the third one but is less expensive to compute
+            any(query_word == s for s in label_variants)
+            or (self.match_word_prefix and any(s.startswith(query_word) for s in label_variants))
+            or any(
+                damerau_levenshtein_distance(query_word, s) <= 1
+                for s in label_variants
+                if len(s) > 2
+            )
+            or any(self.word_matches_abreviation(query_word, s) for s in label_variants)
         )
-        or any(word_matches_abreviation(query_word, s) for s in label_variants)
-    )
 
+    def count_adj_in_same_block(self, terms: List[str], blocks: List[List[str]]) -> int:
+        """
+        Count the number of consecutive terms that both match a word in a same
+        block.
 
-def count_adj_in_same_block(terms: List[str], blocks: List[List[str]]) -> int:
-    """
-    Count the number of consecutive terms that both match a word in a same
-    block.
+        >>> filter = ResultFilter()
+        >>> filter.count_adj_in_same_block(
+        ...     ["rue", "de", "paris", "lille"],
+        ...     [["rue", "de", "paris"], ["lille"]],
+        ... )
+        2
+        >>> filter.count_adj_in_same_block(
+        ...     ["rue", "de", "paris", "lille"],
+        ...     [["rue", "de", "lille"], ["paris"]],
+        ... )
+        1
+        """
 
-    >>> count_adj_in_same_block(
-    ...     ["rue", "de", "paris", "lille"],
-    ...     [["rue", "de", "paris"], ["lille"]],
-    ... )
-    2
-    >>> count_adj_in_same_block(
-    ...     ["rue", "de", "paris", "lille"],
-    ...     [["rue", "de", "lille"], ["paris"]],
-    ... )
-    1
-    """
+        def contains(word: str, block: List[str]) -> bool:
+            return any(self.word_matches(word, block_word) for block_word in block)
 
-    def contains(word: str, block: List[str]) -> bool:
-        return any(word_matches(word, block_word) for block_word in block)
+        return sum(
+            any(contains(word_1, block) and contains(word_2, block) for block in blocks)
+            for word_1, word_2 in zip(terms[:-1], terms[1:])
+        )
 
-    return sum(
-        any(contains(word_1, block) and contains(word_2, block) for block in blocks)
-        for word_1, word_2 in zip(terms[:-1], terms[1:])
-    )
+    def check(
+        self,
+        query: str,
+        names: List[str],
+        place_type: str,
+        admins: List[str] = [],
+        postcodes: List[str] = [],
+    ) -> bool:
+        query_words = self.words(query.lower())
+        names = list(map(str.lower, names))
+        admins = list(map(str.lower, admins))
 
+        if place_type == "house":
+            query_words = [word for word in query_words if word not in self.NUM_SUFFIXES]
 
-def check(
-    query: str,
-    names: List[str],
-    place_type: str,
-    admins: List[str] = [],
-    postcodes: List[str] = [],
-) -> bool:
-    query_words = words(query.lower())
-    names = list(map(str.lower, names))
-    admins = list(map(str.lower, admins))
+        # Check if all words of the query match a word in the result
+        full_label = [
+            *(w for name in names for w in self.words(name)),
+            *postcodes,
+            *(w for admin in admins for w in self.words(admin)),
+        ]
 
-    if place_type == "house":
-        query_words = [word for word in query_words if word not in NUM_SUFFIXES]
+        # Check if enough words in the query are matched in the result
+        query_matches = (
+            any(self.word_matches(q_word, l_word) for l_word in full_label)
+            for q_word in query_words
+        )
 
-    # Check if all words of the query match a word in the result
-    full_label = [
-        *(w for name in names for w in words(name)),
-        *postcodes,
-        *(w for admin in admins for w in words(admin)),
-    ]
+        if self.min_matching_words is None:
+            if not all(query_matches):
+                logger.debug(
+                    "Removed `%s` from results because the query is not covered by the result",
+                    names[0],
+                )
+                return False
+        else:
+            num_matches = sum(query_matches)
 
-    for q_word in query_words:
-        if not any(word_matches(q_word, l_word) for l_word in full_label):
+            if num_matches < min(len(query_words), self.min_matching_words):
+                logger.debug(
+                    "Removed `%s` from results because only %s words match the result",
+                    names[0],
+                    num_matches,
+                )
+                return False
+
+        # Check if at least 2/3 of the result is covered by the query in one of these cases:
+        #   - over one of the result names
+        #   - over one of the result names together with one of the admin names
+        #   - over one of the result names together with a postcode
+        def coverage(terms):
+            return sum(
+                any(self.word_matches(query_word, term) for query_word in query_words)
+                for term in terms
+            ) / len(terms)
+
+        check_coverage = any(
+            coverage(terms) >= (2 / 3)
+            for name_words in map(self.words, names)
+            for terms in [
+                name_words,
+                *(name_words + self.words(admin) for admin in admins),
+                *(name_words + [postcode] for postcode in postcodes),
+            ]
+        )
+
+        if not check_coverage:
             logger.debug(
-                "Removed `%s` from results because queried `%s` does not match the result",
+                "Removed `%s` from results because query `%s` is not accurate enough",
                 names[0],
-                q_word,
+                query,
             )
             return False
 
-    # Check if at least 2/3 of the result is covered by the query in one of these cases:
-    #   - over one of the result names
-    #   - over one of the result names together with one of the admin names
-    #   - over one of the result names together with a postcode
-    def coverage(terms):
-        return sum(
-            any(word_matches(query_word, term) for query_word in query_words) for term in terms
-        ) / len(terms)
+        return True
 
-    check_coverage = any(
-        coverage(terms) >= (2 / 3)
-        for name_words in map(words, names)
-        for terms in [
-            name_words,
-            *(name_words + words(admin) for admin in admins),
-            *(name_words + [postcode] for postcode in postcodes),
-        ]
-    )
+    def rank(
+        self,
+        query: str,
+        names: List[str],
+        place_type: str,
+        admins: List[str] = [],
+        postcodes: List[str] = [],  # pylint: disable = unused-argument
+    ) -> float:
+        query_words = self.words(query.lower())
 
-    if not check_coverage:
-        logger.debug(
-            "Removed `%s` from results because query `%s` is not accurate enough",
-            names[0],
-            query,
-        )
-        return False
+        if place_type == "house":
+            query_words = [word for word in query_words if word not in self.NUM_SUFFIXES]
 
-    return True
-
-
-def rank(
-    query: str,
-    names: List[str],
-    place_type: str,
-    admins: List[str] = [],
-    postcodes: List[str] = [],  # pylint: disable = unused-argument
-) -> float:
-    query_words = words(query.lower())
-
-    if place_type == "house":
-        query_words = [word for word in query_words if word not in NUM_SUFFIXES]
-
-    if place_type in ["street", "house"] and len(query_words) > 1:
-        # Count the number of adjacent words from the query which are both
-        # part of a same field. The intention is to avoid swapping words
-        # between name and admin.
-        # (eg. "rue de Rennes, Paris" vs. "rue de Paris", Rennes)
-        rank_val = (
-            count_adj_in_same_block(
-                query_words,
-                [*map(words, names), *map(words, admins)],
+        if place_type in ["street", "house"] and len(query_words) > 1:
+            # Count the number of adjacent words from the query which are both
+            # part of a same field. The intention is to avoid swapping words
+            # between name and admin.
+            # (eg. "rue de Rennes, Paris" vs. "rue de Paris", Rennes)
+            rank_val = (
+                self.count_adj_in_same_block(
+                    query_words,
+                    [*map(self.words, names), *map(self.words, admins)],
+                )
+                / (len(query_words) - 1)
             )
-            / (len(query_words) - 1)
-        )
-    else:
-        rank_val = 1.0
+        else:
+            rank_val = 1.0
 
-    return rank_val
+        return rank_val
 
+    def rank_bragi_response(self, query: str, bragi_response: dict) -> Optional[float]:
+        """
+        Return an indicative relevance that takes value in [0, 1.0] to reorder
+        results in respect with the query.
+        """
+        return self.rank(**self.build_params_from_bragi(query, bragi_response))
 
-def rank_bragi_response(query: str, bragi_response: dict) -> Optional[float]:
-    """
-    Return an indicative relevance that takes value in [0, 1.0] to reorder
-    results in respect with the query.
-    """
-    return rank(**build_params_from_bragi(query, bragi_response))
+    def check_bragi_response(self, query: str, bragi_response: dict) -> bool:
+        """
+        Filter a feature from bragi responses, please provide the field
+        bragi_response["features"][..]["properties"]["geocoding"].
+        """
+        return self.check(**self.build_params_from_bragi(query, bragi_response))
 
+    @classmethod
+    def build_params_from_bragi(cls, query: str, bragi_response: dict) -> dict:
+        if bragi_response.get("postcode"):
+            postcodes = bragi_response["postcode"].split(";")
+        else:
+            postcodes = list(
+                {
+                    zip
+                    for admin in bragi_response.get("administrative_regions", [])
+                    for zip in admin.get("zip_codes", [])
+                }
+            )
 
-def check_bragi_response(query: str, bragi_response: dict) -> bool:
-    """
-    Filter a feature from bragi responses, please provide the field
-    bragi_response["features"][..]["properties"]["geocoding"].
-    """
-    return check(**build_params_from_bragi(query, bragi_response))
+        name = bragi_response["name"]
+        local_names = [
+            prop["value"]
+            for prop in bragi_response.get("properties", [])
+            if prop["key"].startswith("name:") or prop["key"].startswith("alt_name:")
+        ]
 
-
-def build_params_from_bragi(query: str, bragi_response: dict) -> dict:
-    if bragi_response.get("postcode"):
-        postcodes = bragi_response["postcode"].split(";")
-    else:
-        postcodes = list(
-            {
-                zip
-                for admin in bragi_response.get("administrative_regions", [])
-                for zip in admin.get("zip_codes", [])
-            }
-        )
-
-    name = bragi_response["name"]
-    local_names = [
-        prop["value"]
-        for prop in bragi_response.get("properties", [])
-        if prop["key"].startswith("name:") or prop["key"].startswith("alt_name:")
-    ]
-
-    return {
-        "query": query,
-        "names": [name] + local_names,
-        "admins": [admin["name"] for admin in bragi_response.get("administrative_regions", [])],
-        "postcodes": postcodes,
-        "place_type": bragi_response.get("type"),
-    }
+        return {
+            "query": query,
+            "names": [name] + local_names,
+            "admins": [admin["name"] for admin in bragi_response.get("administrative_regions", [])],
+            "postcodes": postcodes,
+            "place_type": bragi_response.get("type"),
+        }


### PR DESCRIPTION
Allow the `search` endpoint to be a bit more permissive than `instant_answers`:

 - input query can contain only prefix of the result words (without spelling mistakes)
 - part of the input query is allowed not to match (at least 3 words must be relevant)