### PR TITLE
Remove redundant rate limit check on directions by ids route

### DIFF
--- a/idunn/api/directions.py
+++ b/idunn/api/directions.py
@@ -57,7 +57,6 @@ def get_directions(
     request: Request = Depends(directions_request),
 ):
     """Get directions to get from a places to another."""
-    rate_limiter.check_limit_per_client(request)
     try:
         from_place = place_from_id(origin, follow_redirect=True)
         to_place = place_from_id(destination, follow_redirect=True)


### PR DESCRIPTION
This call to `rate_limiter.check_limit_per_client` is redundant with the `directions_request` dependency shared by "get_directions" and "get_directions_with_coordinates" routes.

This has no impact, as this route "get_directions" (used by place ids as parameters) is not currently used by the application.