### PR TITLE
instant answer: Fix an edge case when a Response was used as a Result

### DIFF
--- a/idunn/api/instant_answer.py
+++ b/idunn/api/instant_answer.py
@@ -112,7 +112,7 @@ def build_response(result: InstantAnswerResult, query: str, lang: str):
     )
 
 
-def get_instant_answer_single_place(place_id: str, lang: str):
+def get_instant_answer_single_place(place_id: str, query: str, lang: str) -> Response:
     try:
         place = place_from_id(place_id, follow_redirect=True)
     except Exception:
@@ -122,13 +122,14 @@ def get_instant_answer_single_place(place_id: str, lang: str):
         return no_instant_answer()
 
     detailed_place = place.load_place(lang=lang)
-    return InstantAnswerResult(
+    result = InstantAnswerResult(
         places=[detailed_place],
         source=place.get_source(),
         intention_bbox=None,
         maps_url=maps_urls.get_place_url(place_id),
         maps_frame_url=maps_urls.get_place_url(place_id, no_ui=True),
     )
+    return build_response(result, query=query, lang=lang)
 
 
 async def get_instant_answer_intention(intention, query: str, lang: str):
@@ -250,5 +251,6 @@ async def get_instant_answer(
         return no_instant_answer(query=q, lang=lang, region=user_country)
 
     place_id = geocodings[0][1]["id"]
-    result = await run_in_threadpool(get_instant_answer_single_place, place_id=place_id, lang=lang)
-    return build_response(result, query=q, lang=lang)
+    return await run_in_threadpool(
+        get_instant_answer_single_place, place_id=place_id, query=q, lang=lang
+    )

--- a/tests/test_instant_answer/test_ia_api.py
+++ b/tests/test_instant_answer/test_ia_api.py
@@ -23,6 +23,12 @@ def test_ia_paris(mock_autocomplete_get, mock_NLU_with_city):
     assert place["name"] == "Paris"
 
 
+def test_ia_item_not_found_in_db(mock_autocomplete_get, mock_NLU_with_city):
+    client = TestClient(app)
+    response = client.get("/v1/instant_answer", params={"q": "pavillon paris", "lang": "fr"})
+    assert response.status_code == 204
+
+
 def test_ia_paris_with_region(mock_autocomplete_get, mock_NLU_with_city):
     client = TestClient(app)
     response = client.get(


### PR DESCRIPTION
In the rare case that a result selected from the geocoder response is not found in the database, `get_instant_answer_single_place` returns a 204 Response. (This was introduced by https://github.com/Qwant/idunn/pull/222).   
So the returned type was no longer consistent with its usage (leading to a server error instead of the expected 204).