### PR TITLE
Minor adjustements about categories definitions

### DIFF
--- a/idunn/api/places_list.py
+++ b/idunn/api/places_list.py
@@ -169,7 +169,7 @@ async def get_places_bbox_impl(
     source = params.source
     if source is None:
         if (
-            params.q or (params.category and all(c.pj_filters() for c in params.category))
+            params.q or (params.category and all(c.pj_what() for c in params.category))
         ) and pj_source.bbox_is_covered(params.bbox):
             params.source = PoiSource.PAGESJAUNES
         else:

--- a/idunn/utils/categories.yml
+++ b/idunn/utils/categories.yml
@@ -29,7 +29,7 @@ categories:
 
     # NOTE: This is a legacy alias for shop_supermarket
     supermarket:
-        pj_what: "alimentation"
+        pj_what: "alimentation grande surface"
         pj_filters:
           - "supermarchés, hypermarchés"
         raw_filters:
@@ -168,6 +168,7 @@ categories:
         regex: "cathedral|church|eglise|mosque|synagogue|temple"
         raw_filters:
           - "place_of_worship,*"
+        match_brand: True
 
     recycling:
         regex: "recycl|tri selectif|dechett?err?ie"
@@ -221,7 +222,7 @@ categories:
         raw_filters:
           - "supermarket,*"
           - "mall,*"
-        pj_what: "supermarché"
+        pj_what: "alimentation grande surface"
         pj_filters:
           - "supermarchés, hypermarchés"
 


### PR DESCRIPTION
* `pj_filters` is not defined for new categories (introduced by #67), so `pj_what` should be preferred to check that "pj" source is available for the current category
* adjustment in the query used to fetch supermarkets: some relevant POIs were missing
* allow tag "brand" to match "place_of_worship" category, due to the limitations of the current tagger