### PR TITLE
result_filter: consider all whitespaces as word separators

### DIFF
--- a/idunn/utils/result_filter.py
+++ b/idunn/utils/result_filter.py
@@ -28,7 +28,7 @@ class ResultFilter:
     }
 
     # Regex recognizing any word separators
-    WORD_SEPARATORS = re.compile("|".join([" ", "-", ",", ";", "\\.", "'"]))
+    WORD_SEPARATORS = re.compile("|".join([r"\s+", "-", ",", ";", "\\.", "'"]))
 
     def __init__(
         self,
@@ -53,6 +53,8 @@ class ResultFilter:
         >>> filter = ResultFilter()
         >>> filter.words("17, rue jaune ; Levallois-Peret")
         ['17', 'rue', 'jaune', 'Levallois', 'Peret']
+        >>> filter.words("Rue Censier\xa0Domont")
+        ['Rue', 'Censier', 'Domont']
         """
         return [word for word in cls.WORD_SEPARATORS.split(text) if word]
 


### PR DESCRIPTION
Match all Unicode whitespace characters as word separators, using [`\s`](https://docs.python.org/3.8/library/re.html#index-30).