### PR TITLE
instant_answer: direct queries to pages jaunes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -155,6 +155,7 @@ disable=print-statement,
         too-many-locals,
         too-many-public-methods,
         too-many-return-statements,
+        protected-access,
 # TODO: we may be interested in adding these
         wrong-import-order,
         fixme,

--- a/.pylintrc
+++ b/.pylintrc
@@ -154,6 +154,7 @@ disable=print-statement,
         too-many-instance-attributes,
         too-many-locals,
         too-many-public-methods,
+        too-many-return-statements,
 # TODO: we may be interested in adding these
         wrong-import-order,
         fixme,
@@ -272,7 +273,7 @@ function-naming-style=snake_case
 #function-rgx=
 
 # Good variable names which should always be accepted, separated by a comma.
-good-names=_
+good-names=_,T
 
 # Good variable names regexes, separated by a comma. If names match any regex,
 # they will always be accepted

--- a/idunn/api/instant_answer.py
+++ b/idunn/api/instant_answer.py
@@ -236,7 +236,6 @@ async def get_instant_answer(
                     IntentionType.BRAND,
                     IntentionType.CATEGORY,
                     IntentionType.POI,
-                    IntentionType.ANY_PLACE,
                 ],
             )
             if intentions and intentions[0].type in [
@@ -258,7 +257,7 @@ async def get_instant_answer(
         return await run_in_threadpool(
             pj_source.search_places,
             normalized_query,
-            intentions[0]._place_in_query,
+            intentions[0].description._place_in_query,
         )
 
     bragi_response, pj_response = await asyncio.gather(

--- a/idunn/api/instant_answer.py
+++ b/idunn/api/instant_answer.py
@@ -203,6 +203,7 @@ async def get_instant_answer(
     run more restrictive checks on its results.
     """
     normalized_query = normalize(q)
+    user_country = user_country.lower()
 
     if len(normalized_query) > ia_max_query_length:
         return no_instant_answer(query=q, lang=lang, region=user_country)
@@ -253,16 +254,7 @@ async def get_instant_answer(
             return []
 
         place_in_query = any(it.description.place for it in intentions)
-
-        try:
-            return await run_in_threadpool(
-                pj_source.search_places,
-                normalized_query,
-                place_in_query,
-            )
-        except HTTPException as exc:
-            logger.warning("Failed to query pagejaunes: %s", exc)
-            return []
+        return await run_in_threadpool(pj_source.search_places, normalized_query, place_in_query)
 
     bragi_response, pj_response = await asyncio.gather(
         bragi_client.autocomplete(query), fetch_pj_response()

--- a/idunn/api/instant_answer.py
+++ b/idunn/api/instant_answer.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from fastapi import Query
 from fastapi.responses import ORJSONResponse, Response
@@ -7,9 +8,11 @@ from pydantic import BaseModel, Field, validator, HttpUrl
 from geopy import Point
 
 from idunn import settings
+from idunn.datasources.pages_jaunes import pj_source
 from idunn.geocoder.nlu_client import nlu_client, NluClientException
 from idunn.geocoder.bragi_client import bragi_client
 from idunn.geocoder.models import QueryParams
+from idunn.geocoder.models.geocodejson import IntentionType
 from idunn.places import place_from_id, Place
 from idunn.api.places_list import get_places_bbox_impl, PlacesQueryParam
 from idunn.utils import maps_urls
@@ -223,34 +226,57 @@ async def get_instant_answer(
     if lang in nlu_allowed_languages:
         try:
             intentions = await nlu_client.get_intentions(
-                normalized_query, lang, extra_geocoder_params
+                normalized_query,
+                lang,
+                extra_geocoder_params,
+                allow_types=[
+                    IntentionType.BRAND,
+                    IntentionType.CATEGORY,
+                    IntentionType.PLACE,
+                    IntentionType.POI,
+                ],
             )
-            if intentions:
+            if intentions and intentions[0].type in [
+                IntentionType.BRAND,
+                IntentionType.CATEGORY,
+            ]:
                 return await get_instant_answer_intention(intentions[0], query=q, lang=lang)
         except NluClientException:
             # No intention could be interpreted from query
-            pass
+            intentions = []
 
     # Direct geocoding query
     query = QueryParams.build(q=normalized_query, lang=lang, limit=5, **extra_geocoder_params)
-    bragi_response = await bragi_client.autocomplete(query)
-    geocodings = (feature["properties"]["geocoding"] for feature in bragi_response["features"])
-    geocodings = sorted(
-        (
-            (
-                result_filter.rank_bragi_response(normalized_query, feature),
-                feature,
-            )
-            for feature in geocodings
-            if result_filter.check_bragi_response(normalized_query, feature)
-        ),
-        key=lambda item: -item[0],  # sort by descending rank
+
+    if intentions:
+        bragi_response, pj_response = await asyncio.gather(
+            bragi_client.autocomplete(query),
+            run_in_threadpool(pj_source.search_places, normalized_query),
+        )
+        pj_response = result_filter.filter_places(normalized_query, pj_response)
+    else:
+        bragi_response = await bragi_client.autocomplete(query)
+        pj_response = None
+
+    bragi_features = result_filter.filter_bragi_features(
+        normalized_query, bragi_response["features"]
     )
 
-    if not geocodings:
+    if bragi_features:
+        place_id = bragi_features[0]["properties"]["geocoding"]["id"]
+        res = await run_in_threadpool(
+            get_instant_answer_single_place, query=q, place_id=place_id, lang=lang
+        )
+    elif pj_response:
+        place_id = pj_response[0].get_id()
+        result = InstantAnswerResult(
+            places=[pj_response[0].load_place(lang)],
+            source=pj_response[0].get_source(),
+            maps_url=maps_urls.get_place_url(place_id),
+            maps_frame_url=maps_urls.get_place_url(place_id, no_ui=True),
+        )
+        res = build_response(result, query=q, lang=lang)
+    else:
         return no_instant_answer(query=q, lang=lang, region=user_country)
 
-    place_id = geocodings[0][1]["id"]
-    return await run_in_threadpool(
-        get_instant_answer_single_place, place_id=place_id, query=q, lang=lang
-    )
+    return res

--- a/idunn/api/instant_answer.py
+++ b/idunn/api/instant_answer.py
@@ -258,7 +258,7 @@ async def get_instant_answer(
         return await run_in_threadpool(
             pj_source.search_places,
             normalized_query,
-            intentions.place_in_query,
+            intentions[0]._place_in_query,
         )
 
     bragi_response, pj_response = await asyncio.gather(

--- a/idunn/api/instant_answer.py
+++ b/idunn/api/instant_answer.py
@@ -252,8 +252,14 @@ async def get_instant_answer(
         if not (settings["IA_CALL_PJ_POI"] and user_country == "fr" and intentions):
             return []
 
+        place_in_query = any(it.description.place for it in intentions)
+
         try:
-            return await run_in_threadpool(pj_source.search_places, normalized_query)
+            return await run_in_threadpool(
+                pj_source.search_places,
+                normalized_query,
+                place_in_query,
+            )
         except HTTPException as exc:
             logger.warning("Failed to query pagejaunes: %s", exc)
             return []

--- a/idunn/api/search.py
+++ b/idunn/api/search.py
@@ -32,20 +32,11 @@ async def search(
         return response
 
     # Filter relevent features
-    feasible_features = filter(
-        lambda ft: result_filter.check_bragi_response(query.q, ft.properties.geocoding.dict()),
-        response.features,
-    )
+    feasible_features = result_filter.filter_bragi_features(query.q, response.dict()["features"])
 
     # Pick most relevant feature, if any
-    best_feature = max(
-        feasible_features,
-        default=None,
-        key=lambda ft: result_filter.rank_bragi_response(query.q, ft.properties.geocoding.dict()),
-    )
-
-    if best_feature:
-        response.features = [best_feature]
+    if feasible_features:
+        response.features = [feasible_features[0]]
     else:
         response.features = []
 

--- a/idunn/datasources/pages_jaunes.py
+++ b/idunn/datasources/pages_jaunes.py
@@ -2,6 +2,7 @@ from os import path
 from typing import List
 
 import logging
+import requests
 from elasticsearch import Elasticsearch
 from fastapi import HTTPException
 from requests import HTTPError as RequestsHTTPError
@@ -140,7 +141,12 @@ class ApiPjSource(PjSource):
         return res.json()
 
     def get_places_from_url(self, url, params=None, size=10):
-        res = pj_find.Response(**self.get_from_params(url, params))
+        try:
+            res = pj_find.Response(**self.get_from_params(url, params))
+        except requests.RequestException as exc:
+            logger.error("Failed to query pagejaunes: %s", exc)
+            return []
+
         pois = [PjApiPOI(listing) for listing in res.search_results.listings[:size] or []]
 
         if (

--- a/idunn/datasources/pages_jaunes.py
+++ b/idunn/datasources/pages_jaunes.py
@@ -36,6 +36,10 @@ class PjSource:
     def internal_id(self, poi_id):
         return poi_id.replace(f"{self.PLACE_ID_NAMESPACE}:", "", 1)
 
+    # pylint: disable = unused-argument
+    def search_places(self, query: str, size=10) -> List[PjApiPOI]:
+        return []
+
     def get_places_bbox(self, categories: List[CategoryEnum], bbox, size=10, query=""):
         raise NotImplementedError
 
@@ -151,6 +155,10 @@ class ApiPjSource(PjSource):
             )
 
         return pois
+
+    def search_places(self, query: str, size=10) -> List[PjApiPOI]:
+        query_params = {"q": f"{query} france"}
+        return self.get_places_from_url(self.PJ_FIND_API_URL, query_params, size)
 
     def get_places_bbox(
         self, categories: List[CategoryEnum], bbox, size=10, query=""

--- a/idunn/datasources/pages_jaunes.py
+++ b/idunn/datasources/pages_jaunes.py
@@ -37,7 +37,7 @@ class PjSource:
         return poi_id.replace(f"{self.PLACE_ID_NAMESPACE}:", "", 1)
 
     # pylint: disable = unused-argument
-    def search_places(self, query: str, size=10) -> List[PjApiPOI]:
+    def search_places(self, query: str, place_in_query: bool, size=10) -> List[PjApiPOI]:
         return []
 
     def get_places_bbox(self, categories: List[CategoryEnum], bbox, size=10, query=""):
@@ -156,8 +156,8 @@ class ApiPjSource(PjSource):
 
         return pois
 
-    def search_places(self, query: str, size=10) -> List[PjApiPOI]:
-        query_params = {"q": f"{query} france"}
+    def search_places(self, query: str, place_in_query: bool, size=10) -> List[PjApiPOI]:
+        query_params = {"q": query if place_in_query else f"{query} france"}
         return self.get_places_from_url(self.PJ_FIND_API_URL, query_params, size)
 
     def get_places_bbox(

--- a/idunn/geocoder/models/geocodejson.py
+++ b/idunn/geocoder/models/geocodejson.py
@@ -3,6 +3,7 @@ Implement GeocodeJson specification as defined here:
  - https://github.com/geocoders/geocodejson-spec/tree/master/draft
  - https://github.com/CanalTP/mimirsbrunn/blob/master/libs/bragi/src/model.rs
 """
+from enum import Enum
 from typing import List, Optional, Tuple
 from pydantic import BaseModel, confloat, Field, validator
 
@@ -163,6 +164,14 @@ class Feature(BaseModel):
     context: Optional[Context]
 
 
+class IntentionType(Enum):
+    BRAND = "brand"
+    CATEGORY = "category"
+    PLACE = "place"
+    POI = "poi"
+    STREET = "street"
+
+
 class IntentionFilter(BaseModel):
     q: Optional[str]
     bbox: Optional[Rect]
@@ -177,6 +186,7 @@ class IntentionDescription(BaseModel):
 
 
 class Intention(BaseModel):
+    type: IntentionType
     filter: IntentionFilter = Field(
         ..., description="Filter params that can be passed to /places endpoint"
     )

--- a/idunn/geocoder/models/geocodejson.py
+++ b/idunn/geocoder/models/geocodejson.py
@@ -5,7 +5,7 @@ Implement GeocodeJson specification as defined here:
 """
 from enum import Enum
 from typing import List, Optional, Tuple
-from pydantic import BaseModel, confloat, Field, validator
+from pydantic import BaseModel, PrivateAttr, confloat, Field, validator
 
 from idunn.api.constants import WIKIDATA_TO_BBOX_OVERRIDE
 from .cosmogony import ZoneType
@@ -183,7 +183,7 @@ class IntentionDescription(BaseModel):
     query: Optional[str]
     category: Optional[str]
     place: Optional[Feature]
-    place_in_query: bool = False
+    _place_in_query: bool = PrivateAttr(False)
 
 
 class Intention(BaseModel):

--- a/idunn/geocoder/models/geocodejson.py
+++ b/idunn/geocoder/models/geocodejson.py
@@ -165,11 +165,11 @@ class Feature(BaseModel):
 
 
 class IntentionType(Enum):
+    ADDRESS = "address"
     BRAND = "brand"
     CATEGORY = "category"
-    PLACE = "place"
     POI = "poi"
-    STREET = "street"
+    ANY_PLACE = "any_place"
 
 
 class IntentionFilter(BaseModel):

--- a/idunn/geocoder/models/geocodejson.py
+++ b/idunn/geocoder/models/geocodejson.py
@@ -183,6 +183,7 @@ class IntentionDescription(BaseModel):
     query: Optional[str]
     category: Optional[str]
     place: Optional[Feature]
+    place_in_query: bool = False
 
 
 class Intention(BaseModel):

--- a/idunn/geocoder/nlu_client.py
+++ b/idunn/geocoder/nlu_client.py
@@ -347,16 +347,17 @@ class NLU_Helper:  # pylint: disable = invalid-name
                 logger.info("Detected POI request for '%s'", text, extra=logs_extra)
                 return []
 
-            return [
-                Intention(
-                    type=IntentionType.POI,
-                    filter={"q": text},
-                    description={
-                        "query": text,
-                        "place_in_query": any(t.get("tag") in NLU_PLACE_TAGS for t in tags_list),
-                    },
-                )
-            ]
+            intention = Intention(
+                type=IntentionType.POI,
+                filter={"q": text},
+                description={"query": text},
+            )
+
+            intention.description._place_in_query = any(
+                t.get("tag") in NLU_PLACE_TAGS for t in tags_list
+            )
+
+            return [intention]
 
         if self.is_street_request(tags_list):
             if IntentionType.ADDRESS not in allow_types:

--- a/idunn/geocoder/nlu_client.py
+++ b/idunn/geocoder/nlu_client.py
@@ -351,7 +351,10 @@ class NLU_Helper:  # pylint: disable = invalid-name
                 Intention(
                     type=IntentionType.POI,
                     filter={"q": text},
-                    description={"query": text},
+                    description={
+                        "query": text,
+                        "place_in_query": any(t.get("tag") in NLU_PLACE_TAGS for t in tags_list),
+                    },
                 )
             ]
 

--- a/idunn/utils/circuit_breaker.py
+++ b/idunn/utils/circuit_breaker.py
@@ -33,7 +33,7 @@ class IdunnCircuitBreaker(pybreaker.CircuitBreaker):
             name=name,
         )
 
-    # pylint: disable = arguments-differ, invalid-overridden-method, protected-access
+    # pylint: disable = arguments-differ, invalid-overridden-method
     async def call_async(self, f, *args, **kwargs):
         """
         Run the circuit breaker with native python async.

--- a/idunn/utils/covid19_dataset.py
+++ b/idunn/utils/covid19_dataset.py
@@ -1,5 +1,3 @@
-# pylint: disable = protected-access
-
 import logging
 import csv
 import json

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -188,6 +188,7 @@ RECYCLING_MEASURES_MAX_AGE_IN_HOURS: 168 # 7 days (Older measures will be ignore
 ## Instant Answer
 IA_MAX_QUERY_LENGTH: 100
 IA_SUCCESS_ON_GENERIC_QUERIES: False
+IA_CALL_PJ_POI: True # Early fetch POIs from page jaunes in parallel of Bragi
 
 ###########################
 ## Ban check, for anti-scraping purposes

--- a/tests/test_autocomplete.py
+++ b/tests/test_autocomplete.py
@@ -101,6 +101,7 @@ def test_autocomplete_with_nlu_brand_and_city(mock_autocomplete_get, mock_NLU_wi
         params={"q": "auchan à paris", "lang": "fr", "limit": 7, "nlu": True},
         expected_intention=[
             {
+                "type": "brand",
                 "filter": {"q": "auchan", "bbox": [2.224122, 48.8155755, 2.4697602, 48.902156]},
                 "description": {
                     "query": "auchan",
@@ -117,7 +118,13 @@ def test_autocomplete_with_nlu_brand_no_focus(mock_autocomplete_get, mock_NLU_wi
     assert_intention(
         client,
         params={"q": "auchan", "lang": "fr", "limit": 7, "nlu": True},
-        expected_intention=[{"filter": {"q": "auchan"}, "description": {"query": "auchan"}}],
+        expected_intention=[
+            {
+                "type": "brand",
+                "filter": {"q": "auchan"},
+                "description": {"query": "auchan"},
+            }
+        ],
         expected_intention_place=None,
     )
 
@@ -129,6 +136,7 @@ def test_autocomplete_with_nlu_brand_focus(mock_autocomplete_get, mock_NLU_with_
         params={"q": "auchan", "lang": "fr", "limit": 7, "nlu": True, "lat": 48.9, "lon": 2.3},
         expected_intention=[
             {
+                "type": "brand",
                 "filter": {"q": "auchan"},
                 "description": {"query": "auchan"},
             }
@@ -143,7 +151,11 @@ def test_autocomplete_with_nlu_cat(mock_autocomplete_get, mock_NLU_with_cat):
         client,
         params={"q": "pharmacie", "lang": "fr", "limit": 7, "nlu": True},
         expected_intention=[
-            {"filter": {"category": "pharmacy"}, "description": {"category": "pharmacy"}}
+            {
+                "type": "category",
+                "filter": {"category": "pharmacy"},
+                "description": {"category": "pharmacy"},
+            }
         ],
         expected_intention_place=None,
     )
@@ -156,6 +168,7 @@ def test_autocomplete_with_nlu_country(mock_autocomplete_get, mock_NLU_with_cat_
         params={"q": "pharmacie à paris, france", "lang": "fr", "limit": 7, "nlu": True},
         expected_intention=[
             {
+                "type": "category",
                 "filter": {
                     "category": "pharmacy",
                     "bbox": [2.224122, 48.8155755, 2.4697602, 48.902156],


### PR DESCRIPTION
Query pages jaunes for all queries to instant answers (which are not tagged as addresses), if the geocoder has no result this will be used as a fallback.

This also modifies the `nlu_client` which will now have a field for the "type" of intention to help understanding the nature of the request.