### PR TITLE
images: Use wikipedia thumbnail instead of wikipedia.org URLs

### DIFF
--- a/idunn/blocks/images.py
+++ b/idunn/blocks/images.py
@@ -179,8 +179,11 @@ class ImagesBlock(BaseBlock):
         images = []
 
         # Tag "image"
-        raw_url = place.properties.get("image")
-        if raw_url and raw_url.startswith("http"):
+        raw_url = place.properties.get("image") or ""
+        is_wikipedia_image = "wikipedia.org" in raw_url
+        if raw_url.startswith("http") and not is_wikipedia_image:
+            # Image from "wikipedia.org" are ignored as the .jpg URL often points
+            # to a HTML document, instead of a usable image.
             images.append(
                 cls.build_image(
                     raw_url, source_url=cls.get_source_url(raw_url), alt=place.get_name(lang)

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -113,3 +113,17 @@ def test_tag_mapillary():
 def test_pj_poi_no_image():
     block = ImagesBlock.from_es(PjApiPOI(Listing()), lang="fr")
     assert block is None
+
+
+def test_image_tag_wikipedia():
+    block = ImagesBlock.from_es(
+        POI(
+            {
+                "properties": {
+                    "image": "https://fr.wikipedia.org/wiki/Fichier:Tour_Eiffel_Wikimedia_Commons.jpg"
+                }
+            }
+        ),
+        lang="fr",
+    )
+    assert block is None


### PR DESCRIPTION
The "image" tag may contain a .jpg URL that is actually a HTML document, so the thumbnail extracted from the wikipedia article should be preferred.