### PR TITLE
result_filter: Allow match on postcode only, and on postcode prefix for longer queries

### DIFF
--- a/idunn/api/search.py
+++ b/idunn/api/search.py
@@ -3,7 +3,6 @@ from fastapi import Body, Depends
 
 from idunn import settings
 from idunn.api.geocoder import get_autocomplete
-from idunn.utils import result_filter
 from idunn.utils.result_filter import ResultFilter
 from idunn.instant_answer import normalize
 from ..geocoder.models import ExtraParams, QueryParams, IdunnAutocomplete

--- a/idunn/utils/result_filter.py
+++ b/idunn/utils/result_filter.py
@@ -238,11 +238,11 @@ class ResultFilter:
         candidate_terms_to_cover = (
             terms
             for name_words in map(self.words, names)
-            for terms in [
-                name_words,
-                *(name_words + self.words(admin) for admin in admins),
-                *(name_words + [postcode] for postcode in postcodes),
-            ]
+            for terms in chain(
+                [name_words],
+                (name_words + self.words(admin) for admin in admins),
+                (name_words + [postcode] for postcode in postcodes),
+            )
         )
         if len(query_words) == 1:
             candidate_terms_to_cover = chain(

--- a/tests/test_result_filter.py
+++ b/tests/test_result_filter.py
@@ -108,3 +108,26 @@ def test_min_matching_words():
 
     assert filter.check("5 rue Gustave Eiffel", **place_infos)
     assert not filter.check("5 rue Paul Dupont", **place_infos)
+
+
+def test_match_postcode_by_prefix():
+    filter = ResultFilter()
+    place_infos = {
+        "names": ["Niort"],
+        "postcodes": ["79000"],
+        "place_type": "admin",
+    }
+    assert filter.check("Niort 79", **place_infos)
+    # At least 2 chars must match
+    assert not filter.check("Niort 7", **place_infos)
+
+
+def test_match_postcode_only():
+    filter = ResultFilter()
+    place_infos = {
+        "names": ["Niort"],
+        "postcodes": ["79000"],
+        "place_type": "admin",
+    }
+    assert filter.check("79000", **place_infos)
+    assert not filter.check("79", **place_infos)


### PR DESCRIPTION
The expected behavior is described in additional test cases.  

* a query that consists of a postcode only should match any result with that postcode.
* a postcode prefix (with at least 2 characters) should be considered as a matching word in the query.  
This is especially useful to accept "départements" numbers in France.