### PR TITLE
Define overridden bbox on regions where map position is unexpected

### DIFF
--- a/idunn/api/constants.py
+++ b/idunn/api/constants.py
@@ -7,3 +7,13 @@ class PoiSource(str, Enum):
 
 
 ALL_POI_SOURCES = [s.value for s in PoiSource]
+
+
+WIKIDATA_TO_BBOX_OVERRIDE = {
+    # France -> Metropolitan France
+    "Q142": [-5.4517733, 41.2611155, 9.8282225, 51.3055721],
+    # Tokyo -> Tokyo Metropolis
+    "Q1490": [138.9428648, 35.5012219, 139.9213618, 35.8984245],
+    # San Francisco: exclude marine reserve
+    "Q62": [-122.6164355, 37.7081309, -122.281479, 37.929811],
+}

--- a/idunn/api/utils.py
+++ b/idunn/api/utils.py
@@ -378,35 +378,6 @@ def build_blocks(es_poi, lang, verbosity):
     return blocks
 
 
-def get_geom(es_place):
-    """Return the correct geometry from the elastic response
-
-    A correct geometry means both lat and lon coordinates are required
-    >>> from idunn.places import POI
-    >>> get_geom(POI({})) is None
-    True
-
-    >>> get_geom(POI({'coord':{"lon": None, "lat": 48.858260156496016}})) is None
-    True
-
-    >>> get_geom(POI({'coord':{"lon": 2.2944990157640612, "lat": None}})) is None
-    True
-
-    >>> get_geom(POI({'coord':{"lon": 2.2944990157640612, "lat": 48.858260156496016}}))
-    {'type': 'Point', 'coordinates': [2.2944990157640612, 48.858260156496016], 'center': [2.2944...
-    """
-    geom = None
-    coord = es_place.get_coord()
-    if coord is not None:
-        lon = coord.get("lon")
-        lat = coord.get("lat")
-        if lon is not None and lat is not None:
-            geom = {"type": "Point", "coordinates": [lon, lat], "center": [lon, lat]}
-            if "bbox" in es_place:
-                geom["bbox"] = es_place.get("bbox")
-    return geom
-
-
 def get_name(properties, lang):
     """
     Return the Place name from the properties field of the elastic response. Here 'name'

--- a/idunn/geocoder/models/geocodejson.py
+++ b/idunn/geocoder/models/geocodejson.py
@@ -4,7 +4,9 @@ Implement GeocodeJson specification as defined here:
  - https://github.com/CanalTP/mimirsbrunn/blob/master/libs/bragi/src/model.rs
 """
 from typing import List, Optional, Tuple
-from pydantic import BaseModel, confloat, Field
+from pydantic import BaseModel, confloat, Field, validator
+
+from idunn.api.constants import WIKIDATA_TO_BBOX_OVERRIDE
 from .cosmogony import ZoneType
 
 
@@ -125,6 +127,16 @@ class GeocodingPlace(BaseModel):
     feed_publishers: List[FeedPublished] = []
     bbox: Optional[Rect]
     country_codes: List[str] = []
+
+    @validator("bbox")
+    def override_bbox(cls, v, values):
+        if not v:
+            return v
+        codes = values["codes"]
+        wikidata_id = next((c.value for c in codes if c.name == "wikidata"), None)
+        if wikidata_id in WIKIDATA_TO_BBOX_OVERRIDE:
+            return WIKIDATA_TO_BBOX_OVERRIDE[wikidata_id]
+        return v
 
 
 class FeatureProperties(BaseModel):

--- a/idunn/places/admin.py
+++ b/idunn/places/admin.py
@@ -1,3 +1,5 @@
+from functools import cached_property
+from idunn.api.constants import WIKIDATA_TO_BBOX_OVERRIDE
 from .base import BasePlace
 
 
@@ -15,6 +17,8 @@ class Admin(BasePlace):
         return self.get("names", {}).get(lang) or self.get_local_name()
 
     def get_bbox(self):
+        if self.wikidata_id in WIKIDATA_TO_BBOX_OVERRIDE:
+            return WIKIDATA_TO_BBOX_OVERRIDE[self.wikidata_id]
         return self.get("bbox")
 
     def get_class_name(self):
@@ -23,8 +27,8 @@ class Admin(BasePlace):
     def get_subclass_name(self):
         return self.get("zone_type")
 
-    @property
-    def wikidata_id(self):
+    @cached_property
+    def wikidata_id(self):  # pylint: disable=invalid-overridden-method
         codes = self.get("codes")
         if codes is None:
             return None

--- a/idunn/places/event.py
+++ b/idunn/places/event.py
@@ -37,6 +37,3 @@ class Event(BasePlace):
 
     def get_source(self):
         return self.get("id_events", "").split("_")[0]
-
-    def get_bbox(self):
-        raise NotImplementedError

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -27,3 +27,21 @@ def test_admin():
     assert admin.get_name("fr") == "Dunkerque"
     assert admin.get_name("da") == ""
     assert admin.wikidata_id == "Q7652"
+
+
+def test_admin_bbox_override():
+    admin = Admin(
+        {
+            "zone_type": "city",
+            "codes": [{"name": "wikidata", "value": "Q142"}],
+            "names": {
+                "fr": "France",
+            },
+            "labels": {
+                "fr": "France",
+            },
+        }
+    )
+
+    assert admin.wikidata_id == "Q142"
+    assert admin.get_bbox() == [-5.4517733, 41.2611155, 9.8282225, 51.3055721]


### PR DESCRIPTION
This override needs to be applied on both the `GeocodingPlace` model (used by "/v1/search" and "/v1/autocomplete") and the `BasePlace` class (used by "/v1/places" and "/v1/instant_answer")