### PR TITLE
result_filter: Fix "coverage" for empty terms

### DIFF
--- a/idunn/utils/result_filter.py
+++ b/idunn/utils/result_filter.py
@@ -230,6 +230,8 @@ class ResultFilter:
         #   - over one of the result names together with a postcode
         #   - postcode only, if the query consists of a single word
         def coverage(terms):
+            if len(terms) == 0:
+                return 0.0
             return sum(
                 any(self.word_matches(query_word, term) for query_word in query_words)
                 for term in terms

--- a/tests/test_result_filter.py
+++ b/tests/test_result_filter.py
@@ -131,3 +131,13 @@ def test_match_postcode_only():
     }
     assert filter.check("79000", **place_infos)
     assert not filter.check("79", **place_infos)
+
+
+def test_empty_names():
+    filter = ResultFilter()
+    place_infos = {
+        "names": [".", "Niort"],
+        "postcodes": ["12345"],
+        "place_type": "admin",
+    }
+    assert filter.check("Niort", **place_infos)


### PR DESCRIPTION
`coverage` could raise `ZeroDivisionError` if a field contains no word.