### PR TITLE
autocomplete: Use ORJSONResponse to skip redundant validation

### DIFF
--- a/idunn/api/geocoder.py
+++ b/idunn/api/geocoder.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from fastapi import Body, Depends
+from fastapi.responses import ORJSONResponse
 from ..geocoder.bragi_client import bragi_client
 from ..geocoder.nlu_client import nlu_client, NluClientException
 from ..geocoder.models import QueryParams, ExtraParams, IdunnAutocomplete
@@ -91,3 +92,7 @@ async def get_autocomplete(
             )
         autocomplete_response["intentions"] = intentions
     return IdunnAutocomplete(**autocomplete_response)
+
+
+async def get_autocomplete_response(autocomplete: IdunnAutocomplete = Depends(get_autocomplete)):
+    return ORJSONResponse(autocomplete.dict(exclude_unset=True))

--- a/idunn/api/urls.py
+++ b/idunn/api/urls.py
@@ -7,7 +7,7 @@ from .places_list import get_places_bbox, get_events_bbox, PlacesBboxResponse
 from .categories import AllCategoriesResponse, get_all_categories
 from .closest import closest_address
 from ..directions.models import DirectionsResponse
-from .geocoder import get_autocomplete
+from .geocoder import get_autocomplete_response
 from ..geocoder.models import IdunnAutocomplete
 from .directions import get_directions_with_coordinates, get_directions
 from .urlsolver import follow_redirection
@@ -78,10 +78,9 @@ def get_api_urls(settings):
         # Geocoding
         APIRoute(
             "/autocomplete",
-            get_autocomplete,
+            get_autocomplete_response,
             methods=["GET", "POST"],
             response_model=IdunnAutocomplete,
-            response_model_exclude_unset=True,
         ),
         APIRoute(
             "/search",


### PR DESCRIPTION
This is a small optimization.   
Similarly to `/v1/instant_answer`, returning a direct `Response` bypasses the second redundant model validation that is automatically performed by FastAPI.