### PR TITLE
nlu_client: fallback through regexps when the classifier fails

### DIFF
--- a/idunn/geocoder/nlu_client.py
+++ b/idunn/geocoder/nlu_client.py
@@ -143,7 +143,7 @@ class NLU_Helper:  # pylint: disable = invalid-name
 
     async def classify_category(self, text, is_brand=False):
         if settings["NLU_CLASSIFIER_URL"] and not is_brand:
-            return await self.nlu_classifier(text)
+            return await self.nlu_classifier(text) or self.regex_classifier(text, is_brand=is_brand)
         return self.regex_classifier(text, is_brand=is_brand)
 
     @classmethod

--- a/tests/fixtures/autocomplete/__init__.py
+++ b/tests/fixtures/autocomplete/__init__.py
@@ -11,7 +11,10 @@ CLASSIF_URL = "http://qwant.classif"
 ES_URL = "http://qwant.es"
 
 FIXTURE_AUTOCOMPLETE = read_fixture("fixtures/autocomplete/pavillon_paris.json")
-FIXTURE_CLASSIF_pharmacy = read_fixture("fixtures/autocomplete/classif_pharmacy.json")
+FIXTURE_CLASSIF = {
+    "pharmacie": read_fixture("fixtures/autocomplete/classif_pharmacy.json"),
+    "bank": read_fixture("fixtures/autocomplete/classif_bank.json"),
+}
 
 
 def mock_NLU_for(httpx_mock, dataset):
@@ -20,7 +23,12 @@ def mock_NLU_for(httpx_mock, dataset):
     ):
         nlu_json = read_fixture(f"fixtures/autocomplete/nlu/{dataset}.json")
         httpx_mock.post(NLU_URL).respond(json=nlu_json)
-        httpx_mock.post(CLASSIF_URL).respond(json=FIXTURE_CLASSIF_pharmacy)
+
+        for q, data in FIXTURE_CLASSIF.items():
+            httpx_mock.post(
+                CLASSIF_URL, json={"text": q, "domain": "poi", "language": "fr", "count": 10}
+            ).respond(json=data)
+
         yield nlu_json
 
 
@@ -37,6 +45,11 @@ def mock_NLU_with_brand_and_city(httpx_mock):
 @pytest.fixture
 def mock_NLU_with_cat(httpx_mock):
     yield from mock_NLU_for(httpx_mock, "with_cat")
+
+
+@pytest.fixture
+def mock_NLU_with_cat_bank(httpx_mock):
+    yield from mock_NLU_for(httpx_mock, "with_cat_bank")
 
 
 @pytest.fixture

--- a/tests/fixtures/autocomplete/classif_bank.json
+++ b/tests/fixtures/autocomplete/classif_bank.json
@@ -1,0 +1,21 @@
+{
+    "count": 3,
+    "domain": "poi",
+    "intention": [
+        [
+            1.0000100135803223,
+            "shop_laundry"
+        ],
+        [
+            1.0000100135803223,
+            "bank"
+        ],
+        [
+            1.0000100135803223,
+            "health_pharmacy"
+        ]
+    ],
+    "text": "bank",
+    "tokenized": "bank \n"
+}
+

--- a/tests/fixtures/autocomplete/classif_pharmacy.json
+++ b/tests/fixtures/autocomplete/classif_pharmacy.json
@@ -1,5 +1,5 @@
 {
-    "count": 1,
+    "count": 3,
     "domain": "poi",
     "intention": [
         [

--- a/tests/fixtures/autocomplete/nlu/with_cat_bank.json
+++ b/tests/fixtures/autocomplete/nlu/with_cat_bank.json
@@ -1,0 +1,14 @@
+{
+    "NLU": [
+        {
+            "phrase": "bank",
+            "tag": "cat",
+            "value": {}
+        }
+    ],
+    "count": 1,
+    "domain": "poi",
+    "lang": "fr",
+    "text": "bank",
+    "tokenized": "bank"
+}

--- a/tests/test_autocomplete.py
+++ b/tests/test_autocomplete.py
@@ -9,6 +9,7 @@ from .fixtures.autocomplete import (
     mock_NLU_with_poi,
     mock_NLU_with_brand,
     mock_NLU_with_cat,
+    mock_NLU_with_cat_bank,
     mock_NLU_with_cat_city_country,
     mock_NLU_with_brand_and_city,
 )
@@ -155,6 +156,23 @@ def test_autocomplete_with_nlu_cat(mock_autocomplete_get, mock_NLU_with_cat):
                 "type": "category",
                 "filter": {"category": "pharmacy"},
                 "description": {"category": "pharmacy"},
+            }
+        ],
+        expected_intention_place=None,
+    )
+
+
+def test_autocomplete_with_nlu_regex_cat(mock_autocomplete_get, mock_NLU_with_cat_bank):
+    # "bank" is not identified by the classifier, we expect a fallback through the regex engine.
+    client = TestClient(app)
+    assert_intention(
+        client,
+        params={"q": "bank", "lang": "fr", "limit": 7, "nlu": True},
+        expected_intention=[
+            {
+                "type": "category",
+                "filter": {"category": "bank"},
+                "description": {"category": "bank"},
             }
         ],
         expected_intention_place=None,


### PR DESCRIPTION
This is a simple fix to avoid regressions with common abbreviation or English searches.