### PR TITLE
add NLU_CLIENT_TIMEOUT setting

### DIFF
--- a/idunn/geocoder/nlu_client.py
+++ b/idunn/geocoder/nlu_client.py
@@ -56,7 +56,9 @@ class NLU_Helper:  # pylint: disable = invalid-name
     CLASSIF_MAX_WEIGHT_RATIO = float(settings["NLU_CLASSIFIER_MAX_WEIGHT_RATIO"])
 
     def __init__(self):
-        self.client = httpx.AsyncClient(timeout=0.3, verify=settings["VERIFY_HTTPS"])
+        self.client = httpx.AsyncClient(
+            timeout=float(settings["NLU_CLIENT_TIMEOUT"]), verify=settings["VERIFY_HTTPS"]
+        )
 
     async def post_nlu_classifier(self, text):
         classifier_url = settings["NLU_CLASSIFIER_URL"]

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -132,6 +132,7 @@ BRAGI_BASE_URL: "http://bragi:4000"
 AUTOCOMPLETE_NLU_DEFAULT: False
 AUTOCOMPLETE_NLU_SHADOW_ENABLED: False # if True, NLU APIs are always called, even if nlu intentions are not required by the request
 AUTOCOMPLETE_NLU_FILTER_INTENTIONS: True # Exclude full-text intentions when the query does not match enough results among returned features
+NLU_CLIENT_TIMEOUT: 0.3 # timeout for calls to NLU services, in seconds
 NLU_ALLOWED_LANGUAGES: "en,fr"
 NLU_TAGGER_URL:
 NLU_TAGGER_DOMAIN: "poi"


### PR DESCRIPTION
When using a slow or unstable network the hard-coded 300ms timeout in `nlu_client` can be rather short, this is just a tiny PR to suggest making it configurable.