### PR TITLE
Extend "raw_filters" in categories definitions for OSM POIs, to allow "cuisine" filter

### DIFF
--- a/idunn/api/categories.py
+++ b/idunn/api/categories.py
@@ -5,17 +5,12 @@ from typing import List
 
 class CategoryDescription(BaseModel):
     name: str = Field(..., description="Unique label of the category.")
-    raw_filters: List[str] = Field(..., description="Raw filter on OSM tags.")
 
 
 class AllCategoriesResponse(BaseModel):
     categories: List[CategoryDescription] = Field(..., description="All available categories")
 
 
-def get_all_categories() -> AllCategoriesResponse:
+def get_all_categories():
     """List all available categories."""
-    return {
-        "categories": [
-            {"name": cat.value, "raw_filters": cat.raw_filters()} for cat in list(Category)
-        ]
-    }
+    return {"categories": [{"name": cat.value} for cat in list(Category)]}

--- a/idunn/api/closest.py
+++ b/idunn/api/closest.py
@@ -6,8 +6,9 @@ from pydantic import confloat
 from idunn import settings
 from idunn.utils.es_wrapper import get_elasticsearch
 from idunn.utils import prometheus
-from idunn.places import Street, Address
-from idunn.api.utils import fetch_closest, Verbosity
+from idunn.places import Street, Address, Place
+from idunn.api.utils import Verbosity
+from idunn.datasources.mimirsbrunn import fetch_closest
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +45,7 @@ def closest_address(
     lon: confloat(ge=-180, le=180),
     lang=None,
     verbosity: Verbosity = Verbosity.default(),
-) -> Address:
+) -> Place:
     """Find the closest address to a point."""
 
     es = get_elasticsearch()

--- a/idunn/api/pois.py
+++ b/idunn/api/pois.py
@@ -1,10 +1,10 @@
 from idunn import settings
-from idunn.places import POI
+from idunn.places import POI, Place
 from idunn.utils.es_wrapper import get_elasticsearch
-from idunn.api.utils import fetch_es_poi
+from idunn.datasources.mimirsbrunn import fetch_es_poi
 
 
-def get_poi(id: str, lang: str = None) -> POI:
+def get_poi(id: str, lang: str = None) -> Place:
     """Handler that returns points-of-interest"""
     es = get_elasticsearch()
     if not lang:

--- a/idunn/api/utils.py
+++ b/idunn/api/utils.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from fastapi import HTTPException
 from elasticsearch import (
     Elasticsearch,
     ConnectionError,
@@ -26,10 +25,8 @@ from idunn.blocks import (
     WikiUndefinedException,
 )
 from idunn.utils import prometheus
-from idunn.utils.index_names import INDICES
-from idunn.utils.es_wrapper import get_elasticsearch
-from idunn.places.exceptions import PlaceNotFound
 from idunn.utils.settings import _load_yaml_file
+from idunn.datasources.mimirsbrunn import MimirPoiFilter
 
 logger = logging.getLogger(__name__)
 
@@ -75,8 +72,15 @@ class CategoryEnum(str):
     def pj_what(self):
         return ALL_CATEGORIES[self].get("pj_what")
 
-    def raw_filters(self):
-        return ALL_CATEGORIES[self].get("raw_filters")
+    def raw_filters(self) -> [MimirPoiFilter]:
+        raw_filters = ALL_CATEGORIES[self].get("raw_filters")
+        filters = []
+        for f in raw_filters:
+            f = f.copy()
+            poi_class = f.pop("class", None)
+            poi_subclass = f.pop("subclass", None)
+            filters.append(MimirPoiFilter(poi_class, poi_subclass, extra=f))
+        return filters
 
     def regex(self):
         return ALL_CATEGORIES[self].get("regex")
@@ -149,13 +153,6 @@ BLOCKS_BY_VERBOSITY = {
     Verbosity.SHORT: [OpeningHourBlock, Covid19Block],
 }
 
-PLACE_DEFAULT_INDEX = settings["PLACE_DEFAULT_INDEX"]
-PLACE_POI_INDEX = settings["PLACE_POI_INDEX"]
-PLACE_ADDRESS_INDEX = settings["PLACE_ADDRESS_INDEX"]
-PLACE_STREET_INDEX = settings["PLACE_STREET_INDEX"]
-
-ANY = "*"
-
 
 class WikidataConnector:
     _wiki_es = None
@@ -215,153 +212,6 @@ class WikidataConnector:
 
         wiki = resp[0]["_source"]
         return wiki
-
-
-def fetch_es_poi(id, es) -> dict:
-    """Returns the raw POI data
-    @deprecated by fetch_es_place()
-
-    This function gets from Elasticsearch the
-    entry corresponding to the given id.
-    """
-    try:
-        return fetch_es_place(id, es, type="poi")["_source"]
-    except PlaceNotFound as e:
-        raise HTTPException(status_code=404, detail=e.message) from e
-
-
-def fetch_es_pois(raw_filters, bbox, max_size) -> list:
-    es = get_elasticsearch()
-    left, bot, right, top = bbox[0], bbox[1], bbox[2], bbox[3]
-
-    terms_filters = []
-    for pair in raw_filters:
-        (cls, subcls) = pair.split(",", 1)
-        if (cls, subcls) == (ANY, ANY):
-            terms_filters.append([])
-        elif subcls == ANY:
-            terms_filters.append(["class_" + cls])
-            terms_filters.append([cls])
-        elif cls == ANY:
-            terms_filters.append(["subclass_" + subcls])
-        else:
-            terms_filters.append(["class_" + cls, "subclass_" + subcls])
-
-    should_terms = []
-    for filt in terms_filters:
-        if filt == []:
-            should_terms.append({"match_all": {}})
-        else:
-            should_terms.append(
-                {"bool": {"must": [{"term": {"poi_type.name": term}} for term in filt]}}
-            )
-
-    # pylint: disable = unexpected-keyword-arg
-    bbox_places = es.search(
-        index=INDICES["poi"],
-        body={
-            "query": {
-                "bool": {
-                    "should": should_terms,
-                    "minimum_should_match": 1,
-                    "filter": {
-                        "geo_bounding_box": {
-                            "coord": {
-                                "top_left": {"lat": top, "lon": left},
-                                "bottom_right": {"lat": bot, "lon": right},
-                            }
-                        }
-                    },
-                }
-            },
-            "sort": {"weight": "desc"},
-        },
-        size=max_size,
-        timeout="3s",
-        ignore_unavailable=True,
-    )
-
-    bbox_places = bbox_places.get("hits", {}).get("hits", [])
-    return bbox_places
-
-
-def fetch_es_place(id, es, type) -> dict:
-    """Returns the raw Place data
-
-    This function gets from Elasticsearch the
-    entry corresponding to the given id.
-    """
-    if type is None:
-        index_name = PLACE_DEFAULT_INDEX
-    elif type not in INDICES:
-        raise HTTPException(status_code=400, detail=f"Wrong type parameter: type={type}")
-    else:
-        index_name = INDICES.get(type)
-
-    try:
-        es_places = es.search(
-            index=index_name,
-            body={"query": {"bool": {"filter": {"term": {"_id": id}}}}},
-            ignore_unavailable=True,
-            _source_exclude=["boundary"],
-        )
-    except ElasticsearchException as error:
-        logger.warning("error with database: %s", error)
-        raise HTTPException(detail="database issue", status_code=503) from error
-
-    es_place = es_places.get("hits", {}).get("hits", [])
-    if len(es_place) == 0:
-        if type is None:
-            message = f"place '{id}' not found"
-        else:
-            message = f"place '{id}' not found with type={type}"
-        raise PlaceNotFound(message=message)
-    if len(es_place) > 1:
-        logger.warning("Got multiple places with id %s", id)
-
-    return es_place[0]
-
-
-def fetch_closest(lat, lon, max_distance, es):
-    es_addrs = es.search(
-        index=",".join([PLACE_ADDRESS_INDEX, PLACE_STREET_INDEX]),
-        body={
-            "query": {
-                "function_score": {
-                    "query": {
-                        "bool": {
-                            "filter": {
-                                "geo_distance": {
-                                    "distance": "{}m".format(max_distance),
-                                    "coord": {"lat": lat, "lon": lon},
-                                    "distance_type": "plane",
-                                }
-                            }
-                        }
-                    },
-                    "boost_mode": "replace",
-                    "functions": [
-                        {
-                            "gauss": {
-                                "coord": {
-                                    "origin": {"lat": lat, "lon": lon},
-                                    "scale": "{}m".format(max_distance),
-                                }
-                            }
-                        }
-                    ],
-                }
-            },
-            "from": 0,
-            "size": 1,
-        },
-    )
-    es_addrs = es_addrs.get("hits", {}).get("hits", [])
-    if len(es_addrs) == 0:
-        raise HTTPException(
-            status_code=404, detail=f"nothing around {lat}:{lon} within {max_distance}m..."
-        )
-    return es_addrs[0]
 
 
 def build_blocks(es_poi, lang, verbosity):

--- a/idunn/datasources/mimirsbrunn.py
+++ b/idunn/datasources/mimirsbrunn.py
@@ -1,0 +1,175 @@
+import logging
+from fastapi import HTTPException
+from elasticsearch import ElasticsearchException
+from idunn import settings
+from idunn.utils.es_wrapper import get_elasticsearch
+from idunn.utils.index_names import INDICES
+from idunn.places.exceptions import PlaceNotFound
+
+logger = logging.getLogger(__name__)
+
+PLACE_DEFAULT_INDEX = settings["PLACE_DEFAULT_INDEX"]
+PLACE_POI_INDEX = settings["PLACE_POI_INDEX"]
+PLACE_ADDRESS_INDEX = settings["PLACE_ADDRESS_INDEX"]
+PLACE_STREET_INDEX = settings["PLACE_STREET_INDEX"]
+
+
+class MimirPoiFilter:
+    def __init__(self, poi_class=None, poi_subclass=None, extra=None):
+        self.poi_class = poi_class
+        self.poi_subclass = poi_subclass
+        self.extra = extra or {}
+
+    def get_terms_filters(self):
+        terms = []
+        if self.poi_class:
+            terms.append(f"class_{self.poi_class}")
+        if self.poi_subclass:
+            terms.append(f"subclass_{self.poi_subclass}")
+        for key, value in self.extra.items():
+            terms.append(f"{key}:{value}")
+        return terms
+
+    @classmethod
+    def from_url_raw_filter(cls, raw_filter):
+        poi_class, poi_subclass = raw_filter.split(",", maxsplit=1)
+        if poi_class == "*":
+            poi_class = None
+        if poi_subclass == "*":
+            poi_subclass = None
+        return cls(poi_class, poi_subclass)
+
+
+def fetch_es_pois(filters: [MimirPoiFilter], bbox, max_size) -> list:
+    es = get_elasticsearch()
+    left, bot, right, top = bbox[0], bbox[1], bbox[2], bbox[3]
+
+    should_terms = []
+    for f in filters:
+        terms = f.get_terms_filters()
+        if terms == []:
+            should_terms.append({"match_all": {}})
+        else:
+            should_terms.append(
+                {"bool": {"must": [{"term": {"poi_type.name": term}} for term in terms]}}
+            )
+
+    # pylint: disable = unexpected-keyword-arg
+    bbox_places = es.search(
+        index=INDICES["poi"],
+        body={
+            "query": {
+                "bool": {
+                    "should": should_terms,
+                    "minimum_should_match": 1,
+                    "filter": {
+                        "geo_bounding_box": {
+                            "coord": {
+                                "top_left": {"lat": top, "lon": left},
+                                "bottom_right": {"lat": bot, "lon": right},
+                            }
+                        }
+                    },
+                }
+            },
+            "sort": {"weight": "desc"},
+        },
+        size=max_size,
+        timeout="3s",
+        ignore_unavailable=True,
+    )
+
+    bbox_places = bbox_places.get("hits", {}).get("hits", [])
+    return bbox_places
+
+
+def fetch_es_place(id, es, type) -> dict:
+    """Returns the raw Place data
+
+    This function gets from Elasticsearch the
+    entry corresponding to the given id.
+    """
+    if type is None:
+        index_name = PLACE_DEFAULT_INDEX
+    elif type not in INDICES:
+        raise HTTPException(status_code=400, detail=f"Wrong type parameter: type={type}")
+    else:
+        index_name = INDICES.get(type)
+
+    try:
+        es_places = es.search(
+            index=index_name,
+            body={"query": {"bool": {"filter": {"term": {"_id": id}}}}},
+            ignore_unavailable=True,
+            _source_exclude=["boundary"],
+        )
+    except ElasticsearchException as error:
+        logger.warning("error with database: %s", error)
+        raise HTTPException(detail="database issue", status_code=503) from error
+
+    es_place = es_places.get("hits", {}).get("hits", [])
+    if len(es_place) == 0:
+        if type is None:
+            message = f"place '{id}' not found"
+        else:
+            message = f"place '{id}' not found with type={type}"
+        raise PlaceNotFound(message=message)
+    if len(es_place) > 1:
+        logger.warning("Got multiple places with id %s", id)
+
+    return es_place[0]
+
+
+def fetch_closest(lat, lon, max_distance, es):
+    es_addrs = es.search(
+        index=",".join([PLACE_ADDRESS_INDEX, PLACE_STREET_INDEX]),
+        body={
+            "query": {
+                "function_score": {
+                    "query": {
+                        "bool": {
+                            "filter": {
+                                "geo_distance": {
+                                    "distance": "{}m".format(max_distance),
+                                    "coord": {"lat": lat, "lon": lon},
+                                    "distance_type": "plane",
+                                }
+                            }
+                        }
+                    },
+                    "boost_mode": "replace",
+                    "functions": [
+                        {
+                            "gauss": {
+                                "coord": {
+                                    "origin": {"lat": lat, "lon": lon},
+                                    "scale": "{}m".format(max_distance),
+                                }
+                            }
+                        }
+                    ],
+                }
+            },
+            "from": 0,
+            "size": 1,
+        },
+    )
+    es_addrs = es_addrs.get("hits", {}).get("hits", [])
+    if len(es_addrs) == 0:
+        raise HTTPException(
+            status_code=404, detail=f"nothing around {lat}:{lon} within {max_distance}m..."
+        )
+    return es_addrs[0]
+
+
+def fetch_es_poi(id, es) -> dict:
+    """Returns the raw POI data
+    @deprecated by fetch_es_place()
+
+    This function gets from Elasticsearch the
+    entry corresponding to the given id.
+    """
+    try:
+        return fetch_es_place(id, es, type="poi")["_source"]
+    except PlaceNotFound as e:
+        raise HTTPException(status_code=404, detail=e.message) from e

--- a/idunn/places/utils.py
+++ b/idunn/places/utils.py
@@ -1,6 +1,6 @@
 from idunn.datasources.pages_jaunes import pj_source
+from idunn.datasources.mimirsbrunn import fetch_es_place
 from idunn.utils.es_wrapper import get_elasticsearch
-from idunn.api.utils import fetch_es_place
 from idunn.utils import prometheus
 
 

--- a/idunn/utils/categories.yml
+++ b/idunn/utils/categories.yml
@@ -91,7 +91,7 @@ categories:
           - class: "restaurant"
             cuisine: "burger"
           - class: "fast_food"
-            cuisine: "pizza"
+            cuisine: "burger"
         pj_what: "burger"
 
     food_italian:

--- a/idunn/utils/categories.yml
+++ b/idunn/utils/categories.yml
@@ -6,13 +6,12 @@ categories:
         pj_filters:
           - "salles de cinéma"
         raw_filters:
-          - "cinema,*"
+          - class: "cinema"
 
     # NOTE: This is a legacy alias of `health_hospital`.
     health:
         raw_filters:
-          - "clinic,*"
-          - "hospital,*"
+          - class: "hospital"
         pj_what: "hôpital"
         pj_filters:
           - "Hôpital"
@@ -24,7 +23,7 @@ categories:
         pj_filters:
           - "Pharmacie"
         raw_filters:
-          - "pharmacy,*"
+          - class: "pharmacy"
         regex: "pharmac"
 
     # NOTE: This is a legacy alias for shop_supermarket
@@ -33,8 +32,8 @@ categories:
         pj_filters:
           - "supermarchés, hypermarchés"
         raw_filters:
-          - "*,supermarket"
-          - "*,mall"
+          - subclass: "supermarket"
+          - subclass: "mall"
         regex: "superette|epicier|epicerie|marche|market"
 
     education:
@@ -51,7 +50,7 @@ categories:
           - "enseignement supérieur public"
           - "enseignement supérieur privé"
         raw_filters:
-          - "school,*"
+          - class: "school"
 
     # NOTE: This is a legacy alias for `post_office`
     service:
@@ -59,7 +58,7 @@ categories:
         pj_filters:
           - "envoi, distribution de courrier, de colis"
         raw_filters:
-          - "post_office,*"
+          - subclass: "post_office"
         regex: "(^| )post"
 
     # NOTE: This is a legacy alias for `sport_center`
@@ -70,96 +69,136 @@ categories:
           - "piscines (établissements)"
           - "clubs de sport"
         raw_filters:
-          - "sports_centre,*"
+          - class: "sports_centre"
         regex: "fitness|muscu|piscine"
 
     food_french:
         raw_filters:
-          - "restaurant,french"
+          - class: "restaurant"
+            cuisine: "french"
         pj_what: "restaurant français"
 
     food_pizza:
         raw_filters:
-          - "restaurant,pizza"
+          - class: "restaurant"
+            cuisine: "pizza"
+          - class: "fast_food"
+            cuisine: "pizza"
         pj_what: "pizzeria"
 
     food_burger:
         raw_filters:
-          - "restaurant,burger"
+          - class: "restaurant"
+            cuisine: "burger"
+          - class: "fast_food"
+            cuisine: "pizza"
         pj_what: "burger"
 
     food_italian:
         raw_filters:
-          - "restaurant,italian"
+          - class: "restaurant"
+            cuisine: "italian"
+          - class: "fast_food"
+            cuisine: "italian"
         pj_what: "restaurant italien"
 
     food_kebab:
         raw_filters:
-          - "restaurant,kebab"
+          - class: "restaurant"
+            cuisine: "kebab"
+          - class: "fast_food"
+            cuisine: "kebab"
         pj_what: "kebab"
 
     food_sandwich:
         raw_filters:
-          - "restaurant,sandwich"
+          - class: "restaurant"
+            cuisine: "sandwich"
+          - class: "fast_food"
+            cuisine: "sandwich"
         pj_what: "sandwicherie"
 
     food_asian:
         raw_filters:
-          - "restaurant,asian"
+          - class: "restaurant"
+            cuisine: "asian"
+          - class: "fast_food"
+            cuisine: "asian"
         pj_what: "restaurant asiatique"
 
     food_japanese:
         raw_filters:
-          - "restaurant,japanese"
+          - class: "restaurant"
+            cuisine: "japanese"
+          - class: "fast_food"
+            cuisine: "japanese"
         pj_what: "restaurant japonais"
 
     food_chinese:
         raw_filters:
-          - "restaurant,chinese"
+          - class: "restaurant"
+            cuisine: "chinese"
+          - class: "fast_food"
+            cuisine: "chinese"
         pj_what: "restaurant chinois"
 
     food_crepe:
         raw_filters:
-          - "restaurant,crepe"
+          - class: "restaurant"
+            cuisine: "crepe"
+          - class: "fast_food"
+            cuisine: "crepe"
         pj_what: "crêperie"
 
     food_indian:
         raw_filters:
-          - "restaurant,indian"
+          - class: "restaurant"
+            cuisine: "indian"
+          - class: "fast_food"
+            cuisine: "indian"
         pj_what: "restaurant indien"
 
     food_thai:
         raw_filters:
-          - "restaurant,thai"
+          - class: "restaurant"
+            cuisine: "thai"
+          - class: "fast_food"
+            cuisine: "thai"
         pj_what: "restaurant thaï"
 
     food_vietnamese:
         raw_filters:
-          - "restaurant,vietnamese"
+          - class: "restaurant"
+            cuisine: "vietnamese"
+          - class: "fast_food"
+            cuisine: "vietnamese"
         pj_what: "restaurant vietnamien"
 
     food_lebanese:
         raw_filters:
-          - "restaurant,lebanese"
+          - class: "restaurant"
+            cuisine: "lebanese"
+          - class: "fast_food"
+            cuisine: "lebanese"
         pj_what: "restaurant libanais"
 
     parking:
         regex: "parking"
         raw_filters:
-          - "parking,*"
+          - class: "parking"
 
     pitch:
       raw_filters:
-          - "pitch,*"
-          - "athletics,*"
-          - "running,*"
-          - "soccer,*"
+        - class: "pitch"
+        - class: "athletics"
+        - class: "running"
+        - class: "soccer"
 
     restaurant:
         regex: "^resto|^restau"
         raw_filters:
-          - "restaurant,*"
-          - "fast_food,*"
+          - class: "restaurant"
+          - class: "fast_food"
         pj_what: "restaurants"
         pj_filters:
           - "restaurants"
@@ -167,61 +206,65 @@ categories:
     place_of_worship:
         regex: "cathedral|church|eglise|mosque|synagogue|temple"
         raw_filters:
-          - "place_of_worship,*"
+          - class: "place_of_worship"
         match_brand: True
 
     recycling:
         regex: "recycl|tri selectif|dechett?err?ie"
         raw_filters:
-          - "recycling,*"
+          - class: "recycling"
         match_brand: True
 
     bicycle_parking:
         raw_filters:
-          - "bicycle_parking,*"
+          - class: "bicycle_parking"
 
     school:
         regex: "^ecole|^college"
         raw_filters:
-          - "school,*"
+          - class: "school"
         pj_what: "école collège lycée"
 
     park:
         raw_filters:
-          - "park,*"
-          - "garden,*"
-          - "dog_park,*"
+          - class: "park"
+          - class: "garden"
+          - class: "dog_park"
 
     shop_bakery:
         raw_filters:
-          - "shop,bakery"
-          - "shop,confectionery"
-          - "shop,chocolate"
+          - class: "shop"
+            subclass: "bakery"
+          - class: "shop"
+            subclass: "confectionery"
+          - class: "shop"
+            subclass: "chocolate"
         pj_what: "boulangerie"
 
     shop_clothes:
         raw_filters:
-          - "shop,clothes"
+          - class: "shop"
+            subclass: "clothes"
         pj_what: "boutique de vêtements"
 
     toilets:
         raw_filters:
-          - "toilets,*"
+          - class: "toilets"
 
     sports_centre:
         raw_filters:
-          - "sports_centre,*"
+          - class: "sports_centre"
         pj_what: "centre sportif"
 
     shop_hairdresser:
         raw_filters:
-          - "shop,hairdresser"
+          - subclass: "hairdresser"
         pj_what: "coiffeur"
 
     shop_supermarket:
         raw_filters:
-          - "supermarket,*"
-          - "mall,*"
+          - class: "supermarket"
+          - class: "mall"
         pj_what: "alimentation grande surface"
         pj_filters:
           - "supermarchés, hypermarchés"
@@ -229,23 +272,22 @@ categories:
     bank:
         regex: "^(bank|banque|credit|caisse|atm$)"
         raw_filters:
-          - "bank,*"
+          - class: "bank"
         pj_what: "banque"
         pj_filters:
           - "banques"
 
     fast_food:
         raw_filters:
-          - "fast_food,*"
+          - class: "fast_food"
         pj_what: "fast food"
 
     bar:
         regex: "^(cafes?|bars?|pubs?)( |$)"
         raw_filters:
-          - "bar,*"
-          - "cafe,*"
-          - "pub,*"
-          - "biergarten,*"
+          - class: "bar"
+          - class: "cafe"
+          - class: "beer"
         pj_what: "bar"
         pj_filters:
           - "cafés, bars"
@@ -253,292 +295,297 @@ categories:
     hotel:
         regex: "hotel"
         raw_filters:
-          - "lodging,*"
+          - class: "lodging"
         pj_what: "hôtels"
         pj_filters:
           - "hôtels"
 
     historic:
         raw_filters:
-          - "memorial,*"
-          - "monument,*"
-          - "statue,*"
-          - "castle,*"
-          - "citywalls,*"
-          - "fort,*"
-          - "battlefield,*"
-          - "castle_walls,*"
-          - "earthworks,*"
-          - "moat,*"
-          - "church,*"
-          - "tumulus,*"
-          - "stone_circle,*"
-          - "menhir,*"
-          - "standing_stone,*"
-          - "bridge,*"
-          - "milestone,*"
-          - "wall,*"
-          - "well,*"
-          - "folly,*"
-          - "ruins,*"
+          - class: "memorial"
+          - class: "monument"
+          - class: "statue"
+          - class: "castle"
+          - class: "citywalls"
+          - class: "fort"
+          - class: "battlefield"
+          - class: "castle_walls"
+          - class: "earthworks"
+          - class: "moat"
+          - class: "church"
+          - class: "tumulus"
+          - class: "stone_circle"
+          - class: "menhir"
+          - class: "standing_stone"
+          - class: "bridge"
+          - class: "milestone"
+          - class: "wall"
+          - class: "well"
+          - class: "folly"
 
     post_office:
         raw_filters:
-          - "post_office,*"
+          - subclass: "post_office"
         pj_what: "bureau de poste"
 
     fuel:
         raw_filters:
-          - "fuel,*"
+          - class: "fuel"
         pj_what: "station essence"
 
     community_centre:
         raw_filters:
-          - "*,community_centre"
+          - subclass: "community_centre"
 
     shop_convenience:
         raw_filters:
-          - "*,convenience"
-          - "*,deli"
+          - subclass: "convenience"
+          - subclass: "deli"
         pj_what: "épicerie"
 
     shop_car:
         raw_filters:
-          - "*,car_repair"
-          - "*,car"
+          - subclass: "car_repair"
+          - subclass: "car"
         pj_what: "concessionnaire"
 
     kindergarten:
         raw_filters:
-          - "*,kindergarten"
+          - subclass: "kindergarten"
         pj_what: "crèche"
 
     camp_site:
         raw_filters:
-          - "camp_site,*"
-          - "caravan_site,*"
+          - class: "campsite"
         pj_what: "camping"
 
     station:
         regex: "^gare( |$)"
         raw_filters:
-          - "railway,station"
-          - "railway,halt"
+          - class: "railway"
+            subclass: "station"
+          - class: "railway"
+            subclass: "halt"
 
     shop_butcher:
         raw_filters:
-          - "*,butcher"
+          - subclass: "butcher"
         pj_what: "boucher"
 
     attraction:
         raw_filters:
-          - "nightclub,*"
-          - "leisure,escape_game"
-          - "leisure,golf_course"
-          - "leisure,miniature_golf"
-          - "tourism,aquarium"
-          - "tourism,artwork"
-          - "tourism,attraction"
-          - "tourism,theme_park"
-          - "tourism,zoo"
-          - "water_park,*"
+          - subclass: "nightclub"
+          - subclass: "escape_game"
+          - subclass: "golf_course"
+          - subclass: "miniature_golf"
+          - class: "aquarium"
+            subclass: "aquarium"
+          - class: "art_gallery"
+          - subclass: "attraction"
+          - subclass: "theme_park"
+          - subclass: "zoo"
+          - subclass: "water_park"
 
     health_hospital:
         raw_filters:
-          - "clinic,*"
-          - "hospital,*"
+          - class: "hospital"
         pj_what: "hôpital"
         pj_filters:
           - "Hôpital"
 
     health_doctors:
         raw_filters:
-          - "doctors,*"
-          - "doctor,*"
+          - class: "doctors"
+          - class: "doctor"
         pj_what: "médecin généraliste"
 
     health_dentist:
         raw_filters:
-          - "dentist,*"
+          - class: "dentist"
         pj_what: "dentiste"
 
     health_physiotherapist:
         raw_filters:
-          - "physiotherapist,*"
+          - class: "physiotherapist"
         pj_what: "kinésithérapeute"
 
     health_pharmacy:
         raw_filters:
-          - "pharmacy,*"
+          - class: "pharmacy"
         pj_what: "pharmacie"
         pj_filters:
           - "Pharmacie"
 
     health_psychotherapist:
         raw_filters:
-          - "psychotherapist,*"
+          - class: "psychotherapist"
         pj_what: "psychologue"
 
-    health_other:
-        raw_filters:
-          - "optometrist,*"
-          - "alternative,*"
-          - "audiologist,*"
-          - "birthing_center,*"
-          - "blood_bank,*"
-          - "blood_donation,*"
-          - "centre,*"
-          - "counselling,*"
-          - "dialysis,*"
-          - "laboratory,*"
-          - "midwife,*"
-          - "nurse,*"
-          - "occupational_therapist,*"
-          - "podiatrist,*"
-          - "rehabilitation,*"
-          - "speech_therapist,*"
-        pj_what: "santé"
+#    health_other:
+#        raw_filters:
+#          - class: "optometrist"
+#          - class: "alternative"
+#          - class: "audiologist"
+#          - class: "birthing_center"
+#          - class: "blood_bank"
+#          - class: "blood_donation"
+#          - class: "centre"
+#          - class: "counselling"
+#          - class: "dialysis"
+#          - class: "laboratory"
+#          - class: "midwife"
+#          - class: "nurse"
+#          - class: "occupational_therapist"
+#          - class: "podiatrist"
+#          - class: "rehabilitation"
+#          - class: "speech_therapist"
+#        pj_what: "santé"
 
     library:
         raw_filters:
-          - "library,*"
+          - class: "library"
+            subclass: "library"
         pj_what: "bibliothèque"
 
     police:
         regex: "(^| )(police|gendar)"
         raw_filters:
-          - "police,*"
+          - class: "police"
         pj_what: "police"
         pj_filters:
           - "services de gendarmerie, de police"
 
     shop_optician:
         raw_filters:
-          - "*,optician"
+          - subclass: "optician"
         pj_what: "opticien"
 
     grave_yard:
         raw_filters:
-          - "cemetery,*"
+          - class: "cemetery"
         pj_what: "cimetière"
 
     shop_beauty:
         raw_filters:
-          - "shop,beauty"
+          - subclass: "beauty"
         pj_what: "salon de beauté"
 
     shop_florist:
         raw_filters:
-          - "shop,florist"
+          - subclass: "florist"
         pj_what: "fleuriste"
 
     fire_station:
         raw_filters:
-          - "fire_station,*"
+          - class: "fire_station"
         pj_what: "caserne de pompiers"
 
     shop_shoes:
         raw_filters:
-          - "*,shoes"
+          - subclass: "shoes"
         pj_what: "boutique de chaussures"
 
     shop_doityourself:
         raw_filters:
-          - "*,doityourself"
-          - "*,interior_decoration"
-          - "*,hardware"
+          - subclass: "doityourself"
+          - subclass: "interior_decoration"
+          - subclass: "hardware"
         pj_what: "magasin de bricolage"
 
     bicycle_rental:
         raw_filters:
-          - "bicycle_rental,*"
+          - subclass: "bicycle_rental"
         pj_what: "location de vélo"
 
     museum:
         regex: "^(museum|musee)"
         raw_filters:
-          - "museum,*"
+          - class: "museum"
         pj_what: "musée"
         pj_filters:
           - "musées"
 
     shop_jewelry:
         raw_filters:
-          - "*,jewelry"
+          - subclass: "jewelry"
         pj_what: "bijouterie"
 
     shop_newsagent:
         raw_filters:
-          - "*,newsagent"
-          - "*,kiosk"
+          - subclass: "newsagent"
+          - subclass: "kiosk"
         pj_what: "kiosque à journaux"
 
     swimming:
         raw_filters:
-          - "swimming,*"
+          - class: "swimming"
+          - class: "sports_center"
+            subclass: "swimming"
         pj_what: "piscine"
 
     shop_furniture:
         raw_filters:
-          - "*,furniture"
-          - "*,bed"
+          - subclass: "furniture"
+          - subclass: "bed"
         pj_what: "magasin de meubles"
 
     shop_books:
         raw_filters:
-          - "*,books"
+          - subclass: "books"
         pj_what: "librairie"
 
     shop_laundry:
         raw_filters:
-          - "*,laundry"
+          - class: "laundry"
         pj_what: "blanchisserie"
 
     shop_sports:
         raw_filters:
-          - "shop,sports"
-          - "shop,bicycle"
+          - class: "shop"
+            subclass: "sports"
+          - class: "shop"
+            subclass: "bicycle"
         pj_what: "magasin de sport"
 
     theatre:
         regex: "^theat"
         raw_filters:
-          - "theatre,*"
+          - class: "theatre"
         pj_what: "théâtre"
         pj_filters:
           - "salles de concerts, de spectacles"
 
     veterinary:
         raw_filters:
-          - "veterinary,*"
+          - class: "veterinary"
         pj_what: "vétérinaire"
 
     shop_greengrocer:
         raw_filters:
-          - "*,greengrocer"
+          - subclass: "greengrocer"
         pj_what: "marchant de fruits et légumes"
 
     shop_garden_centre:
         raw_filters:
-          - "*,garden_centre"
+          - subclass: "garden_centre"
         pj_what: "magasin de jardinage"
 
     arts_centre:
         raw_filters:
-          - "arts_centre,*"
-          - "gallery,*"
+          - subclass: "arts_centre"
+          - subclass: "gallery"
         pj_what: "galerie d'art"
 
     shop_electronics:
         raw_filters:
-          - "*,electronics"
-          - "*,computer"
+          - subclass: "electronics"
+          - subclass: "computer"
         pj_what: "magasin d'électronique"
 
     cinema:
         regex: "^cine"
         raw_filters:
-          - "cinema,*"
+          - class: "cinema"
         pj_what: "cinéma"
         pj_filters:
           - "salles de cinéma"
@@ -546,38 +593,39 @@ categories:
     university:
         regex: "^universit|educat"
         raw_filters:
-          - "college,*"
+          - class: "college"
         pj_what: "université"
 
     shop_travel_agency:
         raw_filters:
-          - "*,travel_agency"
+          - subclass: "travel_agency"
         pj_what: "agence de voyage"
 
     sport_other:
         raw_filters:
-          - "sport,*"
-          - "landuse,winter_sports"
+          - class: "sport"
+          - subclass: "winter_sports"
         pj_what: "sport"
 
     administrative:
         raw_filters:
-          - "townhall,*"
-          - "courthouse,*"
-          - "embassy,*"
+          - subclass: "townhall"
+          - subclass: "courthouse"
+          - subclass: "embassy"
+          - subclass: "diplomatic"
         pj_what: "administration"
 
     post_box:
         raw_filters:
-          - "*,post_box"
+          - subclass: "post_box"
 
     playground:
         raw_filters:
-          - "playground,*"
+          - class: "playground"
 
     marketplace:
         raw_filters:
-          - "*,marketplace"
+          - subclass: "marketplace"
 
 
 outing_types:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -204,6 +204,7 @@ def load_all(mimir_client, init_indices):
     load_place("basket_ball.json", mimir_client)
     load_place("recycling.json", mimir_client)
     load_place("recycling_not_in_bretagne.json", mimir_client)
+    load_place("creperie.json", mimir_client)
     load_place("admin_goujounac.json", mimir_client, doc_type="admin")
     load_place("street_birnenweg.json", mimir_client, doc_type="street")
     load_place("address_du_moulin.json", mimir_client, doc_type="addr")

--- a/tests/fixtures/basket_ball.json
+++ b/tests/fixtures/basket_ball.json
@@ -35,7 +35,7 @@
   "poi_type": [
     {
       "id": "museum",
-      "name": "museum"
+      "name": "class_museum"
     }
   ],
   "zip_codes": null,

--- a/tests/fixtures/cinema_multiplexe.json
+++ b/tests/fixtures/cinema_multiplexe.json
@@ -105,7 +105,7 @@
   ],
   "poi_type": {
     "id": "cinema",
-    "name": "cinema"
+    "name": "class_cinema"
   },
   "properties": [
     {

--- a/tests/fixtures/creperie.json
+++ b/tests/fixtures/creperie.json
@@ -1,0 +1,1342 @@
+{
+  "id": "osm:node:738932437",
+  "label": "La Crêpe Flambée (Brest)",
+  "name": "La Crêpe Flambée",
+  "coord": {
+    "lon": -4.482684857765321,
+    "lat": 48.391147170013696
+  },
+  "approx_coord": {
+    "coordinates": [
+      -4.482684857765321,
+      48.391147170013696
+    ],
+    "type": "Point"
+  },
+  "administrative_regions": [
+    {
+      "id": "admin:osm:relation:1076124",
+      "insee": "29019",
+      "level": 8,
+      "label": "Brest (29200), Finistère, Bretagne, France",
+      "name": "Brest",
+      "zip_codes": [
+        "29200"
+      ],
+      "weight": 0.00010004571428571428,
+      "approx_coord": null,
+      "coord": {
+        "lon": -4.4860088,
+        "lat": 48.3905283
+      },
+      "administrative_regions": [
+        {
+          "id": "admin:osm:relation:102430",
+          "insee": "29",
+          "level": 6,
+          "label": "Finistère, Bretagne, France",
+          "name": "Finistère",
+          "zip_codes": [],
+          "weight": 0.00004539285714285714,
+          "approx_coord": null,
+          "coord": {
+            "lon": -4.1024782,
+            "lat": 47.9960325
+          },
+          "administrative_regions": [],
+          "bbox": [
+            -5.1440329,
+            47.7012815,
+            -3.3866547,
+            48.7571916
+          ],
+          "zone_type": "state_district",
+          "parent_id": "admin:osm:relation:102740",
+          "country_codes": [],
+          "codes": [
+            {
+              "name": "ISO3166-2",
+              "value": "FR-29"
+            },
+            {
+              "name": "ref:INSEE",
+              "value": "29"
+            },
+            {
+              "name": "ref:NUTS",
+              "value": "FR522"
+            },
+            {
+              "name": "wikidata",
+              "value": "Q3389"
+            }
+          ],
+          "names": {
+            "br": "Penn-ar-Bed",
+            "ca": "Finisterre",
+            "es": "Finisterre",
+            "fr": "Finistère"
+          },
+          "labels": {
+            "br": "Penn-ar-Bed, Breizh, Bro-C'hall",
+            "ca": "Finisterre, Bretanya, França",
+            "de": "Finistère, Bretagne, Frankreich",
+            "en": "Finistère, Brittany, France",
+            "es": "Finisterre, Bretaña, Francia",
+            "it": "Finistère, Bretagna, Francia"
+          },
+          "context": null
+        },
+        {
+          "id": "admin:osm:relation:102740",
+          "insee": "53",
+          "level": 4,
+          "label": "Bretagne, France",
+          "name": "Bretagne",
+          "zip_codes": [],
+          "weight": 0.002298405,
+          "approx_coord": null,
+          "coord": {
+            "lon": -1.6800198,
+            "lat": 48.1113387
+          },
+          "administrative_regions": [],
+          "bbox": [
+            -5.1440329,
+            47.277755,
+            -1.01569,
+            48.9086459
+          ],
+          "zone_type": "state",
+          "parent_id": "admin:osm:relation:2202162",
+          "country_codes": [],
+          "codes": [
+            {
+              "name": "ISO3166-2",
+              "value": "FR-BRE"
+            },
+            {
+              "name": "ref:INSEE",
+              "value": "53"
+            },
+            {
+              "name": "ref:NUTS",
+              "value": "FR52"
+            },
+            {
+              "name": "wikidata",
+              "value": "Q12130"
+            }
+          ],
+          "names": {
+            "br": "Breizh",
+            "ca": "Bretanya",
+            "de": "Bretagne",
+            "en": "Brittany",
+            "es": "Bretaña",
+            "fr": "Bretagne",
+            "it": "Bretagna"
+          },
+          "labels": {
+            "br": "Breizh, Bro-C'hall",
+            "ca": "Bretanya, França",
+            "de": "Bretagne, Frankreich",
+            "en": "Brittany, France",
+            "es": "Bretaña, Francia",
+            "it": "Bretagna, Francia"
+          },
+          "context": null
+        },
+        {
+          "id": "admin:osm:relation:2202162",
+          "insee": "",
+          "level": 2,
+          "label": "France",
+          "name": "France",
+          "zip_codes": [],
+          "weight": 0.04648105857142857,
+          "approx_coord": null,
+          "coord": {
+            "lon": 2.3514616,
+            "lat": 48.8566969
+          },
+          "administrative_regions": [],
+          "bbox": [
+            -178.3873749,
+            -50.2187169,
+            172.30571519999998,
+            51.3055721
+          ],
+          "zone_type": "country",
+          "parent_id": null,
+          "country_codes": [
+            "FR"
+          ],
+          "codes": [
+            {
+              "name": "ISO3166-1",
+              "value": "FR"
+            },
+            {
+              "name": "ISO3166-1:alpha2",
+              "value": "FR"
+            },
+            {
+              "name": "ISO3166-1:alpha3",
+              "value": "FRA"
+            },
+            {
+              "name": "ISO3166-1:numeric",
+              "value": "250"
+            },
+            {
+              "name": "wikidata",
+              "value": "Q142"
+            }
+          ],
+          "names": {
+            "br": "Bro-C'hall",
+            "ca": "França",
+            "de": "Frankreich",
+            "en": "France",
+            "es": "Francia",
+            "fr": "France",
+            "it": "Francia"
+          },
+          "labels": {
+            "br": "Bro-C'hall",
+            "ca": "França",
+            "de": "Frankreich",
+            "es": "Francia",
+            "it": "Francia"
+          },
+          "context": null
+        }
+      ],
+      "bbox": [
+        -4.5689169,
+        48.3572972,
+        -4.4278311,
+        48.4595521
+      ],
+      "zone_type": "city",
+      "parent_id": "admin:osm:relation:102430",
+      "country_codes": [],
+      "codes": [
+        {
+          "name": "ref:FR:SIREN",
+          "value": "212900195"
+        },
+        {
+          "name": "ref:INSEE",
+          "value": "29019"
+        },
+        {
+          "name": "wikidata",
+          "value": "Q12193"
+        }
+      ],
+      "names": {
+        "br": "Brest",
+        "fr": "Brest"
+      },
+      "labels": {
+        "br": "Brest (29200), Penn-ar-Bed, Breizh, Bro-C'hall",
+        "ca": "Brest (29200), Finisterre, Bretanya, França",
+        "de": "Brest (29200), Finistère, Bretagne, Frankreich",
+        "en": "Brest (29200), Finistère, Brittany, France",
+        "es": "Brest (29200), Finisterre, Bretaña, Francia",
+        "it": "Brest (29200), Finistère, Bretagna, Francia"
+      },
+      "context": null
+    },
+    {
+      "id": "admin:osm:relation:102430",
+      "insee": "29",
+      "level": 6,
+      "label": "Finistère, Bretagne, France",
+      "name": "Finistère",
+      "zip_codes": [],
+      "weight": 0.00004539285714285714,
+      "approx_coord": null,
+      "coord": {
+        "lon": -4.1024782,
+        "lat": 47.9960325
+      },
+      "administrative_regions": [
+        {
+          "id": "admin:osm:relation:102740",
+          "insee": "53",
+          "level": 4,
+          "label": "Bretagne, France",
+          "name": "Bretagne",
+          "zip_codes": [],
+          "weight": 0.002298405,
+          "approx_coord": null,
+          "coord": {
+            "lon": -1.6800198,
+            "lat": 48.1113387
+          },
+          "administrative_regions": [],
+          "bbox": [
+            -5.1440329,
+            47.277755,
+            -1.01569,
+            48.9086459
+          ],
+          "zone_type": "state",
+          "parent_id": "admin:osm:relation:2202162",
+          "country_codes": [],
+          "codes": [
+            {
+              "name": "ISO3166-2",
+              "value": "FR-BRE"
+            },
+            {
+              "name": "ref:INSEE",
+              "value": "53"
+            },
+            {
+              "name": "ref:NUTS",
+              "value": "FR52"
+            },
+            {
+              "name": "wikidata",
+              "value": "Q12130"
+            }
+          ],
+          "names": {
+            "br": "Breizh",
+            "ca": "Bretanya",
+            "de": "Bretagne",
+            "en": "Brittany",
+            "es": "Bretaña",
+            "fr": "Bretagne",
+            "it": "Bretagna"
+          },
+          "labels": {
+            "br": "Breizh, Bro-C'hall",
+            "ca": "Bretanya, França",
+            "de": "Bretagne, Frankreich",
+            "en": "Brittany, France",
+            "es": "Bretaña, Francia",
+            "it": "Bretagna, Francia"
+          },
+          "context": null
+        },
+        {
+          "id": "admin:osm:relation:2202162",
+          "insee": "",
+          "level": 2,
+          "label": "France",
+          "name": "France",
+          "zip_codes": [],
+          "weight": 0.04648105857142857,
+          "approx_coord": null,
+          "coord": {
+            "lon": 2.3514616,
+            "lat": 48.8566969
+          },
+          "administrative_regions": [],
+          "bbox": [
+            -178.3873749,
+            -50.2187169,
+            172.30571519999998,
+            51.3055721
+          ],
+          "zone_type": "country",
+          "parent_id": null,
+          "country_codes": [
+            "FR"
+          ],
+          "codes": [
+            {
+              "name": "ISO3166-1",
+              "value": "FR"
+            },
+            {
+              "name": "ISO3166-1:alpha2",
+              "value": "FR"
+            },
+            {
+              "name": "ISO3166-1:alpha3",
+              "value": "FRA"
+            },
+            {
+              "name": "ISO3166-1:numeric",
+              "value": "250"
+            },
+            {
+              "name": "wikidata",
+              "value": "Q142"
+            }
+          ],
+          "names": {
+            "br": "Bro-C'hall",
+            "ca": "França",
+            "de": "Frankreich",
+            "en": "France",
+            "es": "Francia",
+            "fr": "France",
+            "it": "Francia"
+          },
+          "labels": {
+            "br": "Bro-C'hall",
+            "ca": "França",
+            "de": "Frankreich",
+            "es": "Francia",
+            "it": "Francia"
+          },
+          "context": null
+        }
+      ],
+      "bbox": [
+        -5.1440329,
+        47.7012815,
+        -3.3866547,
+        48.7571916
+      ],
+      "zone_type": "state_district",
+      "parent_id": "admin:osm:relation:102740",
+      "country_codes": [],
+      "codes": [
+        {
+          "name": "ISO3166-2",
+          "value": "FR-29"
+        },
+        {
+          "name": "ref:INSEE",
+          "value": "29"
+        },
+        {
+          "name": "ref:NUTS",
+          "value": "FR522"
+        },
+        {
+          "name": "wikidata",
+          "value": "Q3389"
+        }
+      ],
+      "names": {
+        "br": "Penn-ar-Bed",
+        "ca": "Finisterre",
+        "es": "Finisterre",
+        "fr": "Finistère"
+      },
+      "labels": {
+        "br": "Penn-ar-Bed, Breizh, Bro-C'hall",
+        "ca": "Finisterre, Bretanya, França",
+        "de": "Finistère, Bretagne, Frankreich",
+        "en": "Finistère, Brittany, France",
+        "es": "Finisterre, Bretaña, Francia",
+        "it": "Finistère, Bretagna, Francia"
+      },
+      "context": null
+    },
+    {
+      "id": "admin:osm:relation:102740",
+      "insee": "53",
+      "level": 4,
+      "label": "Bretagne, France",
+      "name": "Bretagne",
+      "zip_codes": [],
+      "weight": 0.002298405,
+      "approx_coord": null,
+      "coord": {
+        "lon": -1.6800198,
+        "lat": 48.1113387
+      },
+      "administrative_regions": [
+        {
+          "id": "admin:osm:relation:2202162",
+          "insee": "",
+          "level": 2,
+          "label": "France",
+          "name": "France",
+          "zip_codes": [],
+          "weight": 0.04648105857142857,
+          "approx_coord": null,
+          "coord": {
+            "lon": 2.3514616,
+            "lat": 48.8566969
+          },
+          "administrative_regions": [],
+          "bbox": [
+            -178.3873749,
+            -50.2187169,
+            172.30571519999998,
+            51.3055721
+          ],
+          "zone_type": "country",
+          "parent_id": null,
+          "country_codes": [
+            "FR"
+          ],
+          "codes": [
+            {
+              "name": "ISO3166-1",
+              "value": "FR"
+            },
+            {
+              "name": "ISO3166-1:alpha2",
+              "value": "FR"
+            },
+            {
+              "name": "ISO3166-1:alpha3",
+              "value": "FRA"
+            },
+            {
+              "name": "ISO3166-1:numeric",
+              "value": "250"
+            },
+            {
+              "name": "wikidata",
+              "value": "Q142"
+            }
+          ],
+          "names": {
+            "br": "Bro-C'hall",
+            "ca": "França",
+            "de": "Frankreich",
+            "en": "France",
+            "es": "Francia",
+            "fr": "France",
+            "it": "Francia"
+          },
+          "labels": {
+            "br": "Bro-C'hall",
+            "ca": "França",
+            "de": "Frankreich",
+            "es": "Francia",
+            "it": "Francia"
+          },
+          "context": null
+        }
+      ],
+      "bbox": [
+        -5.1440329,
+        47.277755,
+        -1.01569,
+        48.9086459
+      ],
+      "zone_type": "state",
+      "parent_id": "admin:osm:relation:2202162",
+      "country_codes": [],
+      "codes": [
+        {
+          "name": "ISO3166-2",
+          "value": "FR-BRE"
+        },
+        {
+          "name": "ref:INSEE",
+          "value": "53"
+        },
+        {
+          "name": "ref:NUTS",
+          "value": "FR52"
+        },
+        {
+          "name": "wikidata",
+          "value": "Q12130"
+        }
+      ],
+      "names": {
+        "br": "Breizh",
+        "ca": "Bretanya",
+        "de": "Bretagne",
+        "en": "Brittany",
+        "es": "Bretaña",
+        "fr": "Bretagne",
+        "it": "Bretagna"
+      },
+      "labels": {
+        "br": "Breizh, Bro-C'hall",
+        "ca": "Bretanya, França",
+        "de": "Bretagne, Frankreich",
+        "en": "Brittany, France",
+        "es": "Bretaña, Francia",
+        "it": "Bretagna, Francia"
+      },
+      "context": null
+    },
+    {
+      "id": "admin:osm:relation:2202162",
+      "insee": "",
+      "level": 2,
+      "label": "France",
+      "name": "France",
+      "zip_codes": [],
+      "weight": 0.04648105857142857,
+      "approx_coord": null,
+      "coord": {
+        "lon": 2.3514616,
+        "lat": 48.8566969
+      },
+      "administrative_regions": [],
+      "bbox": [
+        -178.3873749,
+        -50.2187169,
+        172.30571519999998,
+        51.3055721
+      ],
+      "zone_type": "country",
+      "parent_id": null,
+      "country_codes": [
+        "FR"
+      ],
+      "codes": [
+        {
+          "name": "ISO3166-1",
+          "value": "FR"
+        },
+        {
+          "name": "ISO3166-1:alpha2",
+          "value": "FR"
+        },
+        {
+          "name": "ISO3166-1:alpha3",
+          "value": "FRA"
+        },
+        {
+          "name": "ISO3166-1:numeric",
+          "value": "250"
+        },
+        {
+          "name": "wikidata",
+          "value": "Q142"
+        }
+      ],
+      "names": {
+        "br": "Bro-C'hall",
+        "ca": "França",
+        "de": "Frankreich",
+        "en": "France",
+        "es": "Francia",
+        "fr": "France",
+        "it": "Francia"
+      },
+      "labels": {
+        "br": "Bro-C'hall",
+        "ca": "França",
+        "de": "Frankreich",
+        "es": "Francia",
+        "it": "Francia"
+      },
+      "context": null
+    }
+  ],
+  "weight": 0,
+  "zip_codes": [
+    "29200"
+  ],
+  "poi_type": {
+    "id": "class_restaurant:subclass_restaurant",
+    "name": "class_restaurant subclass_restaurant cuisine:crepe"
+  },
+  "properties": [
+    {
+      "key": "name_int",
+      "value": "La Crêpe Flambée"
+    },
+    {
+      "key": "contact:email",
+      "value": "lacrepeflambee@gmail.com"
+    },
+    {
+      "key": "wheelchair",
+      "value": "yes"
+    },
+    {
+      "key": "contact:phone",
+      "value": "+33 2 98440032"
+    },
+    {
+      "key": "amenity",
+      "value": "restaurant"
+    },
+    {
+      "key": "name",
+      "value": "La Crêpe Flambée"
+    },
+    {
+      "key": "cuisine",
+      "value": "crepe"
+    },
+    {
+      "key": "addr:city",
+      "value": "Brest"
+    },
+    {
+      "key": "name:latin",
+      "value": "La Crêpe Flambée"
+    },
+    {
+      "key": "poi_subclass",
+      "value": "restaurant"
+    },
+    {
+      "key": "poi_class",
+      "value": "restaurant"
+    }
+  ],
+  "address": {
+    "type": "addr",
+    "id": "addr:-4.482707;48.391110:3",
+    "name": "3 Rue Saint-Saëns",
+    "house_number": "3",
+    "street": {
+      "id": "street:",
+      "name": "Rue Saint-Saëns",
+      "administrative_regions": [
+        {
+          "id": "admin:osm:relation:1076124",
+          "insee": "29019",
+          "level": 8,
+          "label": "Brest (29200), Finistère, Bretagne, France",
+          "name": "Brest",
+          "zip_codes": [
+            "29200"
+          ],
+          "weight": 0.00010004571428571428,
+          "approx_coord": null,
+          "coord": {
+            "lon": -4.4860088,
+            "lat": 48.3905283
+          },
+          "administrative_regions": [
+            {
+              "id": "admin:osm:relation:102430",
+              "insee": "29",
+              "level": 6,
+              "label": "Finistère, Bretagne, France",
+              "name": "Finistère",
+              "zip_codes": [],
+              "weight": 0.00004539285714285714,
+              "approx_coord": null,
+              "coord": {
+                "lon": -4.1024782,
+                "lat": 47.9960325
+              },
+              "administrative_regions": [],
+              "bbox": [
+                -5.1440329,
+                47.7012815,
+                -3.3866547,
+                48.7571916
+              ],
+              "zone_type": "state_district",
+              "parent_id": "admin:osm:relation:102740",
+              "country_codes": [],
+              "codes": [
+                {
+                  "name": "ISO3166-2",
+                  "value": "FR-29"
+                },
+                {
+                  "name": "ref:INSEE",
+                  "value": "29"
+                },
+                {
+                  "name": "ref:NUTS",
+                  "value": "FR522"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q3389"
+                }
+              ],
+              "names": {
+                "br": "Penn-ar-Bed",
+                "ca": "Finisterre",
+                "es": "Finisterre",
+                "fr": "Finistère"
+              },
+              "labels": {
+                "br": "Penn-ar-Bed, Breizh, Bro-C'hall",
+                "ca": "Finisterre, Bretanya, França",
+                "de": "Finistère, Bretagne, Frankreich",
+                "en": "Finistère, Brittany, France",
+                "es": "Finisterre, Bretaña, Francia",
+                "it": "Finistère, Bretagna, Francia"
+              },
+              "context": null
+            },
+            {
+              "id": "admin:osm:relation:102740",
+              "insee": "53",
+              "level": 4,
+              "label": "Bretagne, France",
+              "name": "Bretagne",
+              "zip_codes": [],
+              "weight": 0.002298405,
+              "approx_coord": null,
+              "coord": {
+                "lon": -1.6800198,
+                "lat": 48.1113387
+              },
+              "administrative_regions": [],
+              "bbox": [
+                -5.1440329,
+                47.277755,
+                -1.01569,
+                48.9086459
+              ],
+              "zone_type": "state",
+              "parent_id": "admin:osm:relation:2202162",
+              "country_codes": [],
+              "codes": [
+                {
+                  "name": "ISO3166-2",
+                  "value": "FR-BRE"
+                },
+                {
+                  "name": "ref:INSEE",
+                  "value": "53"
+                },
+                {
+                  "name": "ref:NUTS",
+                  "value": "FR52"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q12130"
+                }
+              ],
+              "names": {
+                "br": "Breizh",
+                "ca": "Bretanya",
+                "de": "Bretagne",
+                "en": "Brittany",
+                "es": "Bretaña",
+                "fr": "Bretagne",
+                "it": "Bretagna"
+              },
+              "labels": {
+                "br": "Breizh, Bro-C'hall",
+                "ca": "Bretanya, França",
+                "de": "Bretagne, Frankreich",
+                "en": "Brittany, France",
+                "es": "Bretaña, Francia",
+                "it": "Bretagna, Francia"
+              },
+              "context": null
+            },
+            {
+              "id": "admin:osm:relation:2202162",
+              "insee": "",
+              "level": 2,
+              "label": "France",
+              "name": "France",
+              "zip_codes": [],
+              "weight": 0.04648105857142857,
+              "approx_coord": null,
+              "coord": {
+                "lon": 2.3514616,
+                "lat": 48.8566969
+              },
+              "administrative_regions": [],
+              "bbox": [
+                -178.3873749,
+                -50.2187169,
+                172.30571519999998,
+                51.3055721
+              ],
+              "zone_type": "country",
+              "parent_id": null,
+              "country_codes": [
+                "FR"
+              ],
+              "codes": [
+                {
+                  "name": "ISO3166-1",
+                  "value": "FR"
+                },
+                {
+                  "name": "ISO3166-1:alpha2",
+                  "value": "FR"
+                },
+                {
+                  "name": "ISO3166-1:alpha3",
+                  "value": "FRA"
+                },
+                {
+                  "name": "ISO3166-1:numeric",
+                  "value": "250"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q142"
+                }
+              ],
+              "names": {
+                "br": "Bro-C'hall",
+                "ca": "França",
+                "de": "Frankreich",
+                "en": "France",
+                "es": "Francia",
+                "fr": "France",
+                "it": "Francia"
+              },
+              "labels": {
+                "br": "Bro-C'hall",
+                "ca": "França",
+                "de": "Frankreich",
+                "es": "Francia",
+                "it": "Francia"
+              },
+              "context": null
+            }
+          ],
+          "bbox": [
+            -4.5689169,
+            48.3572972,
+            -4.4278311,
+            48.4595521
+          ],
+          "zone_type": "city",
+          "parent_id": "admin:osm:relation:102430",
+          "country_codes": [],
+          "codes": [
+            {
+              "name": "ref:FR:SIREN",
+              "value": "212900195"
+            },
+            {
+              "name": "ref:INSEE",
+              "value": "29019"
+            },
+            {
+              "name": "wikidata",
+              "value": "Q12193"
+            }
+          ],
+          "names": {
+            "br": "Brest",
+            "fr": "Brest"
+          },
+          "labels": {
+            "br": "Brest (29200), Penn-ar-Bed, Breizh, Bro-C'hall",
+            "ca": "Brest (29200), Finisterre, Bretanya, França",
+            "de": "Brest (29200), Finistère, Bretagne, Frankreich",
+            "en": "Brest (29200), Finistère, Brittany, France",
+            "es": "Brest (29200), Finisterre, Bretaña, Francia",
+            "it": "Brest (29200), Finistère, Bretagna, Francia"
+          },
+          "context": null
+        },
+        {
+          "id": "admin:osm:relation:102430",
+          "insee": "29",
+          "level": 6,
+          "label": "Finistère, Bretagne, France",
+          "name": "Finistère",
+          "zip_codes": [],
+          "weight": 0.00004539285714285714,
+          "approx_coord": null,
+          "coord": {
+            "lon": -4.1024782,
+            "lat": 47.9960325
+          },
+          "administrative_regions": [
+            {
+              "id": "admin:osm:relation:102740",
+              "insee": "53",
+              "level": 4,
+              "label": "Bretagne, France",
+              "name": "Bretagne",
+              "zip_codes": [],
+              "weight": 0.002298405,
+              "approx_coord": null,
+              "coord": {
+                "lon": -1.6800198,
+                "lat": 48.1113387
+              },
+              "administrative_regions": [],
+              "bbox": [
+                -5.1440329,
+                47.277755,
+                -1.01569,
+                48.9086459
+              ],
+              "zone_type": "state",
+              "parent_id": "admin:osm:relation:2202162",
+              "country_codes": [],
+              "codes": [
+                {
+                  "name": "ISO3166-2",
+                  "value": "FR-BRE"
+                },
+                {
+                  "name": "ref:INSEE",
+                  "value": "53"
+                },
+                {
+                  "name": "ref:NUTS",
+                  "value": "FR52"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q12130"
+                }
+              ],
+              "names": {
+                "br": "Breizh",
+                "ca": "Bretanya",
+                "de": "Bretagne",
+                "en": "Brittany",
+                "es": "Bretaña",
+                "fr": "Bretagne",
+                "it": "Bretagna"
+              },
+              "labels": {
+                "br": "Breizh, Bro-C'hall",
+                "ca": "Bretanya, França",
+                "de": "Bretagne, Frankreich",
+                "en": "Brittany, France",
+                "es": "Bretaña, Francia",
+                "it": "Bretagna, Francia"
+              },
+              "context": null
+            },
+            {
+              "id": "admin:osm:relation:2202162",
+              "insee": "",
+              "level": 2,
+              "label": "France",
+              "name": "France",
+              "zip_codes": [],
+              "weight": 0.04648105857142857,
+              "approx_coord": null,
+              "coord": {
+                "lon": 2.3514616,
+                "lat": 48.8566969
+              },
+              "administrative_regions": [],
+              "bbox": [
+                -178.3873749,
+                -50.2187169,
+                172.30571519999998,
+                51.3055721
+              ],
+              "zone_type": "country",
+              "parent_id": null,
+              "country_codes": [
+                "FR"
+              ],
+              "codes": [
+                {
+                  "name": "ISO3166-1",
+                  "value": "FR"
+                },
+                {
+                  "name": "ISO3166-1:alpha2",
+                  "value": "FR"
+                },
+                {
+                  "name": "ISO3166-1:alpha3",
+                  "value": "FRA"
+                },
+                {
+                  "name": "ISO3166-1:numeric",
+                  "value": "250"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q142"
+                }
+              ],
+              "names": {
+                "br": "Bro-C'hall",
+                "ca": "França",
+                "de": "Frankreich",
+                "en": "France",
+                "es": "Francia",
+                "fr": "France",
+                "it": "Francia"
+              },
+              "labels": {
+                "br": "Bro-C'hall",
+                "ca": "França",
+                "de": "Frankreich",
+                "es": "Francia",
+                "it": "Francia"
+              },
+              "context": null
+            }
+          ],
+          "bbox": [
+            -5.1440329,
+            47.7012815,
+            -3.3866547,
+            48.7571916
+          ],
+          "zone_type": "state_district",
+          "parent_id": "admin:osm:relation:102740",
+          "country_codes": [],
+          "codes": [
+            {
+              "name": "ISO3166-2",
+              "value": "FR-29"
+            },
+            {
+              "name": "ref:INSEE",
+              "value": "29"
+            },
+            {
+              "name": "ref:NUTS",
+              "value": "FR522"
+            },
+            {
+              "name": "wikidata",
+              "value": "Q3389"
+            }
+          ],
+          "names": {
+            "br": "Penn-ar-Bed",
+            "ca": "Finisterre",
+            "es": "Finisterre",
+            "fr": "Finistère"
+          },
+          "labels": {
+            "br": "Penn-ar-Bed, Breizh, Bro-C'hall",
+            "ca": "Finisterre, Bretanya, França",
+            "de": "Finistère, Bretagne, Frankreich",
+            "en": "Finistère, Brittany, France",
+            "es": "Finisterre, Bretaña, Francia",
+            "it": "Finistère, Bretagna, Francia"
+          },
+          "context": null
+        },
+        {
+          "id": "admin:osm:relation:102740",
+          "insee": "53",
+          "level": 4,
+          "label": "Bretagne, France",
+          "name": "Bretagne",
+          "zip_codes": [],
+          "weight": 0.002298405,
+          "approx_coord": null,
+          "coord": {
+            "lon": -1.6800198,
+            "lat": 48.1113387
+          },
+          "administrative_regions": [
+            {
+              "id": "admin:osm:relation:2202162",
+              "insee": "",
+              "level": 2,
+              "label": "France",
+              "name": "France",
+              "zip_codes": [],
+              "weight": 0.04648105857142857,
+              "approx_coord": null,
+              "coord": {
+                "lon": 2.3514616,
+                "lat": 48.8566969
+              },
+              "administrative_regions": [],
+              "bbox": [
+                -178.3873749,
+                -50.2187169,
+                172.30571519999998,
+                51.3055721
+              ],
+              "zone_type": "country",
+              "parent_id": null,
+              "country_codes": [
+                "FR"
+              ],
+              "codes": [
+                {
+                  "name": "ISO3166-1",
+                  "value": "FR"
+                },
+                {
+                  "name": "ISO3166-1:alpha2",
+                  "value": "FR"
+                },
+                {
+                  "name": "ISO3166-1:alpha3",
+                  "value": "FRA"
+                },
+                {
+                  "name": "ISO3166-1:numeric",
+                  "value": "250"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q142"
+                }
+              ],
+              "names": {
+                "br": "Bro-C'hall",
+                "ca": "França",
+                "de": "Frankreich",
+                "en": "France",
+                "es": "Francia",
+                "fr": "France",
+                "it": "Francia"
+              },
+              "labels": {
+                "br": "Bro-C'hall",
+                "ca": "França",
+                "de": "Frankreich",
+                "es": "Francia",
+                "it": "Francia"
+              },
+              "context": null
+            }
+          ],
+          "bbox": [
+            -5.1440329,
+            47.277755,
+            -1.01569,
+            48.9086459
+          ],
+          "zone_type": "state",
+          "parent_id": "admin:osm:relation:2202162",
+          "country_codes": [],
+          "codes": [
+            {
+              "name": "ISO3166-2",
+              "value": "FR-BRE"
+            },
+            {
+              "name": "ref:INSEE",
+              "value": "53"
+            },
+            {
+              "name": "ref:NUTS",
+              "value": "FR52"
+            },
+            {
+              "name": "wikidata",
+              "value": "Q12130"
+            }
+          ],
+          "names": {
+            "br": "Breizh",
+            "ca": "Bretanya",
+            "de": "Bretagne",
+            "en": "Brittany",
+            "es": "Bretaña",
+            "fr": "Bretagne",
+            "it": "Bretagna"
+          },
+          "labels": {
+            "br": "Breizh, Bro-C'hall",
+            "ca": "Bretanya, França",
+            "de": "Bretagne, Frankreich",
+            "en": "Brittany, France",
+            "es": "Bretaña, Francia",
+            "it": "Bretagna, Francia"
+          },
+          "context": null
+        },
+        {
+          "id": "admin:osm:relation:2202162",
+          "insee": "",
+          "level": 2,
+          "label": "France",
+          "name": "France",
+          "zip_codes": [],
+          "weight": 0.04648105857142857,
+          "approx_coord": null,
+          "coord": {
+            "lon": 2.3514616,
+            "lat": 48.8566969
+          },
+          "administrative_regions": [],
+          "bbox": [
+            -178.3873749,
+            -50.2187169,
+            172.30571519999998,
+            51.3055721
+          ],
+          "zone_type": "country",
+          "parent_id": null,
+          "country_codes": [
+            "FR"
+          ],
+          "codes": [
+            {
+              "name": "ISO3166-1",
+              "value": "FR"
+            },
+            {
+              "name": "ISO3166-1:alpha2",
+              "value": "FR"
+            },
+            {
+              "name": "ISO3166-1:alpha3",
+              "value": "FRA"
+            },
+            {
+              "name": "ISO3166-1:numeric",
+              "value": "250"
+            },
+            {
+              "name": "wikidata",
+              "value": "Q142"
+            }
+          ],
+          "names": {
+            "br": "Bro-C'hall",
+            "ca": "França",
+            "de": "Frankreich",
+            "en": "France",
+            "es": "Francia",
+            "fr": "France",
+            "it": "Francia"
+          },
+          "labels": {
+            "br": "Bro-C'hall",
+            "ca": "França",
+            "de": "Frankreich",
+            "es": "Francia",
+            "it": "Francia"
+          },
+          "context": null
+        }
+      ],
+      "label": "Rue Saint-Saëns (Brest)",
+      "weight": 0.00010004571428571428,
+      "approx_coord": null,
+      "coord": {
+        "lon": -4.482707,
+        "lat": 48.39111
+      },
+      "zip_codes": [
+        "29200"
+      ],
+      "country_codes": [
+        "FR"
+      ],
+      "context": null
+    },
+    "label": "3 Rue Saint-Saëns (Brest)",
+    "coord": {
+      "lon": -4.482707,
+      "lat": 48.39111
+    },
+    "approx_coord": null,
+    "weight": 0.00010004571428571428,
+    "zip_codes": [
+      "29200"
+    ],
+    "country_codes": [
+      "FR"
+    ],
+    "context": null
+  },
+  "country_codes": [
+    "FR"
+  ],
+  "names": {
+    "fr": "La Crêpe Flambée"
+  },
+  "labels": {
+    "fr": "La Crêpe Flambée (Brest)"
+  },
+  "context": null
+}

--- a/tests/fixtures/fake_all_blocks.json
+++ b/tests/fixtures/fake_all_blocks.json
@@ -387,7 +387,7 @@
   "poi_type": [
     {
       "id": "museum",
-      "name": "museum"
+      "name": "class_museum"
     }
   ],
   "properties": [

--- a/tests/fixtures/patisserie_peron.json
+++ b/tests/fixtures/patisserie_peron.json
@@ -105,7 +105,7 @@
   ],
   "poi_type": {
     "id": "bakery",
-    "name": "bakery"
+    "name": "class_bakery"
   },
   "properties": [
     {

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -663,3 +663,15 @@ def test_pj_categories_filter_legacy(enable_pj_source):
     assert len(resp["places"]) == 1
     assert resp["places"][0]["id"] == "pj:05360257"
     assert resp["places"][0]["name"] == "Musée Picasso"
+
+
+def test_category_with_cuisine_filter():
+    client = TestClient(app)
+    response = client.get(
+        url=f"http://localhost/v1/places?bbox={BBOX_BREST}&category=food_crepe&source=osm"
+    )
+
+    assert response.status_code == 200
+    resp = response.json()
+    assert len(resp["places"]) == 1
+    assert resp["places"][0]["name"] == "La Crêpe Flambée"


### PR DESCRIPTION
In "categories.yaml", the `raw_filters` (used in ES queries) are now defined with objects that accept the following keys : `class`, `subclass`, `cuisine`.   
The new `MimirPoiFilter` is responsible for translating these values into appropriate `poi_type.name` values (see https://github.com/Qwant/fafnir/pull/61)

All functions related to queries in ES for documents built by Mimirsbrunn importers are moved to "idunn/datasources/mimirsbrunn.py".

The new implementation removes a deprecated behavior about "class" filters: both `{poi_class}` and `class_{poi_class}` were accepted. The first format is obsolete. That's why a few existing fixtures need to be updated.

