### PR TITLE
pj: Fix result_filter on PjApiPOI with no address

### DIFF
--- a/idunn/places/base.py
+++ b/idunn/places/base.py
@@ -143,7 +143,7 @@ class BasePlace(dict):
     def build_admin(self, _lang=None):
         return None
 
-    def build_admins(self, lang=None):
+    def build_admins(self, lang=None) -> list:
         raw_admins = self.get_raw_admins()
         admins = []
         if not raw_admins is None:

--- a/idunn/places/pj_poi.py
+++ b/idunn/places/pj_poi.py
@@ -183,7 +183,7 @@ class PjPOI(BasePlace):
             "country_code": self.get_country_code(),
         }
 
-    def build_admins(self, lang=None):
+    def build_admins(self, lang=None) -> list:
         city = self.get_city()
         postcode = self.get_postcode()
 
@@ -354,11 +354,11 @@ class PjApiPOI(BasePlace):
             "country_code": self.get_country_code(),
         }
 
-    def build_admins(self, lang=None):
+    def build_admins(self, lang=None) -> list:
         inscription = self.get_inscription_with_address()
 
         if not inscription:
-            return None
+            return []
 
         city = inscription.address_city
         postcode = inscription.address_zipcode


### PR DESCRIPTION
`ResultFilter.build_params_from_place()` expects that `place.build_admins()` is iterable.