### PR TITLE
Add new block: social

### DIFF
--- a/idunn/api/utils.py
+++ b/idunn/api/utils.py
@@ -24,6 +24,7 @@ from idunn.blocks import (
     WebSiteBlock,
     WikiUndefinedException,
     TransactionalBlock,
+    SocialBlock,
 )
 from idunn.utils import prometheus
 from idunn.utils.settings import _load_yaml_file
@@ -141,6 +142,7 @@ BLOCKS_BY_VERBOSITY = {
         GradesBlock,
         RecyclingBlock,
         TransactionalBlock,
+        SocialBlock,
     ],
     Verbosity.LIST: [
         OpeningDayEvent,
@@ -153,6 +155,7 @@ BLOCKS_BY_VERBOSITY = {
         GradesBlock,
         RecyclingBlock,
         TransactionalBlock,
+        SocialBlock,
     ],
     Verbosity.SHORT: [OpeningHourBlock, Covid19Block],
 }

--- a/idunn/blocks/__init__.py
+++ b/idunn/blocks/__init__.py
@@ -32,6 +32,7 @@ from .environment import (
 
 from .recycling import RecyclingBlock
 from .transactional import TransactionalBlock
+from .social import SocialBlock
 
 AnyBlock = Union[
     OpeningHourBlock,
@@ -54,4 +55,5 @@ AnyBlock = Union[
     Weather,
     RecyclingBlock,
     TransactionalBlock,
+    SocialBlock,
 ]

--- a/idunn/blocks/social.py
+++ b/idunn/blocks/social.py
@@ -1,0 +1,41 @@
+from enum import Enum
+from typing import List, Literal
+
+from pydantic import BaseModel
+
+from .base import BaseBlock
+
+
+class Site(str, Enum):
+    FACEBOOK = "facebook"
+    TWITTER = "twitter"
+    INSTAGRAM = "instagram"
+    YOUTUBE = "youtube"
+
+
+class Link(BaseModel):
+    site: Site
+    url: str
+
+
+class SocialBlock(BaseBlock):
+    type: Literal["social"] = "social"
+    links: List[Link]
+
+    @classmethod
+    def from_es(cls, place, lang):
+        links = [
+            Link(site=site, url=url)
+            for site, url in [
+                (Site.FACEBOOK, place.get_facebook()),
+                (Site.TWITTER, place.get_twitter()),
+                (Site.INSTAGRAM, place.get_instagram()),
+                (Site.YOUTUBE, place.get_youtube()),
+            ]
+            if url
+        ]
+
+        if not links:
+            return None
+
+        return cls(links=links)

--- a/idunn/places/base.py
+++ b/idunn/places/base.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from geopy import Point
 from pytz import timezone, UTC
 
@@ -184,12 +185,41 @@ class BasePlace(dict):
         return phone.split(";")[0]
 
     def get_website(self):
-        return self.find_property_value(
-            ["contact:website", "website", "facebook", "contact:facebook"]
-        )
+        return self.find_property_value(["contact:website", "website"])
 
     def get_website_label(self):
         return None
+
+    @staticmethod
+    def build_social_if_not_url(template, field):
+        if field is None or re.match("^https?://", field):
+            return field
+
+        return template.format(field.lstrip("@"))
+
+    def get_facebook(self):
+        return self.build_social_if_not_url(
+            "https://www.facebook.com/{}",
+            self.find_property_value(["facebook", "contact:facebook"]),
+        )
+
+    def get_twitter(self):
+        return self.build_social_if_not_url(
+            "https://twitter.com/{}",
+            self.find_property_value(["twitter", "contact:twitter"]),
+        )
+
+    def get_instagram(self):
+        return self.build_social_if_not_url(
+            "https://www.instagram.com/{}",
+            self.find_property_value(["instagram", "contact:instagram"]),
+        )
+
+    def get_youtube(self):
+        return self.build_social_if_not_url(
+            "https://www.youtube.com/{}",
+            self.find_property_value(["contact:youtube"]),
+        )
 
     def get_coord(self):
         return self.get("coord")

--- a/idunn/places/models/pj_find.py
+++ b/idunn/places/models/pj_find.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
-from .pj_info import TransactionalLink
+from .pj_info import TransactionalLink, WebsiteUrl
 
 
 class BusinessDescription(BaseModel):
@@ -83,10 +83,6 @@ class Urls(BaseModel):
     )
 
 
-class WebsiteUrls(BaseModel):
-    website_url: Optional[str] = Field(None, description="URL of merchant website")
-
-
 class Context(BaseModel):
     """
     Omitted fields:
@@ -142,7 +138,7 @@ class Listing(BaseModel):
     )
     merchant_name: Optional[str] = Field(None, description="Name of the merchant")
     thumbnail_url: Optional[str] = Field(None, description="URL for the merchant main thumbnail")
-    website_urls: List[WebsiteUrls] = Field([], description="Array of merchant websites URLs")
+    website_urls: List[WebsiteUrl] = Field([], description="Array of merchant websites URLs")
     business_descriptions: List[BusinessDescription] = Field(
         [], description="Array of business description object"
     )

--- a/idunn/places/models/pj_info.py
+++ b/idunn/places/models/pj_info.py
@@ -125,14 +125,14 @@ class Urls(BaseModel):
 
 
 class UrlType(Enum):
-    NON_SOCIAL = "NON_SOCIAL"
+    EXTERNAL_WEBSITE = "SITE_EXTERNE"
     FACEBOOK = "FACEBOOK"
     TWITTER = "TWITTER"
     INSTAGRAM = "INSTAGRAM"
 
 
 class WebsiteUrl(BaseModel):
-    url_type: UrlType = Field(UrlType.NON_SOCIAL, description="URL type of merchant website")
+    url_type: Optional[UrlType] = Field(None, description="URL type of merchant website")
     website_url: Optional[str] = Field(None, description="URL of merchant website")
     suggested_label: Optional[str] = Field(None, description="Suggested label of merchant website")
 
@@ -141,7 +141,8 @@ class WebsiteUrl(BaseModel):
         try:
             return UrlType(field)
         except ValueError:
-            return UrlType.NON_SOCIAL
+            logger.warning("Got unknown url type from pagesjaunes: %s", field)
+            return None
 
 
 class Inscription(BaseModel):

--- a/idunn/places/models/pj_info.py
+++ b/idunn/places/models/pj_info.py
@@ -128,6 +128,7 @@ class UrlType(Enum):
     NON_SOCIAL = "NON_SOCIAL"
     FACEBOOK = "FACEBOOK"
     TWITTER = "TWITTER"
+    INSTAGRAM = "INSTAGRAM"
 
 
 class WebsiteUrl(BaseModel):

--- a/idunn/places/models/pj_info.py
+++ b/idunn/places/models/pj_info.py
@@ -124,14 +124,23 @@ class Urls(BaseModel):
     )
 
 
-class WebsiteUrl(BaseModel):
-    """
-    Omitted fields:
-      - url_type: URL type of merchant website
-    """
+class UrlType(Enum):
+    NON_SOCIAL = "NON_SOCIAL"
+    FACEBOOK = "FACEBOOK"
+    TWITTER = "TWITTER"
 
+
+class WebsiteUrl(BaseModel):
+    url_type: UrlType = Field(UrlType.NON_SOCIAL, description="URL type of merchant website")
     website_url: Optional[str] = Field(None, description="URL of merchant website")
     suggested_label: Optional[str] = Field(None, description="Suggested label of merchant website")
+
+    @validator("url_type", pre=True)
+    def validate_url_type(cls, field: str):
+        try:
+            return UrlType(field)
+        except ValueError:
+            return UrlType.NON_SOCIAL
 
 
 class Inscription(BaseModel):

--- a/idunn/places/pj_poi.py
+++ b/idunn/places/pj_poi.py
@@ -284,14 +284,14 @@ class PjApiPOI(BasePlace):
         )
 
     def get_website(self):
-        return self.get_website_url_for_type(UrlType.NON_SOCIAL)
+        return self.get_website_url_for_type(UrlType.EXTERNAL_WEBSITE)
 
     def get_website_label(self):
         if isinstance(self.data, pj_find.Listing):
             # FIXME: Ideally the Listing would include a "suggested_label" too
             return self.get_local_name()
 
-        suggested_label = self.get_website_url_for_type(UrlType.NON_SOCIAL)
+        suggested_label = self.get_website_url_for_type(UrlType.EXTERNAL_WEBSITE)
         prefix = "Voir le site "
 
         if not suggested_label:

--- a/idunn/places/pj_poi.py
+++ b/idunn/places/pj_poi.py
@@ -291,8 +291,15 @@ class PjApiPOI(BasePlace):
             # FIXME: Ideally the Listing would include a "suggested_label" too
             return self.get_local_name()
 
-        suggested_label = self.get_website_url_for_type(UrlType.EXTERNAL_WEBSITE)
         prefix = "Voir le site "
+        suggested_label = next(
+            (
+                website.suggested_label
+                for website in self.data.website_urls or []
+                if website.url_type == UrlType.EXTERNAL_WEBSITE
+            ),
+            None,
+        )
 
         if not suggested_label:
             return None

--- a/idunn/places/pj_poi.py
+++ b/idunn/places/pj_poi.py
@@ -273,34 +273,29 @@ class PjApiPOI(BasePlace):
             None,
         )
 
-    def get_website(self):
+    def get_website_url_for_type(self, social_network: UrlType) -> Optional[str]:
         return next(
             (
                 resolve_url(website.website_url)
                 for website in self.data.website_urls or []
-                if website.url_type == UrlType.NON_SOCIAL
+                if website.url_type == social_network
             ),
             None,
         )
 
-    def get_website_label(self):
-        if not self.data.website_urls:
-            return None
+    def get_website(self):
+        return self.get_website_url_for_type(UrlType.NON_SOCIAL)
 
+    def get_website_label(self):
         if isinstance(self.data, pj_find.Listing):
             # FIXME: Ideally the Listing would include a "suggested_label" too
             return self.get_local_name()
 
-        suggested_label = next(
-            (
-                website.suggested_label
-                for website in self.data.website_urls or []
-                if website.url_type == UrlType.NON_SOCIAL
-            ),
-            None,
-        )
-
+        suggested_label = self.get_website_url_for_type(UrlType.NON_SOCIAL)
         prefix = "Voir le site "
+
+        if not suggested_label:
+            return None
 
         if suggested_label.startswith(prefix):
             return suggested_label[len(prefix) :]
@@ -308,27 +303,13 @@ class PjApiPOI(BasePlace):
         return suggested_label
 
     def get_facebook(self):
-        return next(
-            (
-                resolve_url(website.website_url)
-                for website in self.data.website_urls or []
-                if website.url_type == UrlType.FACEBOOK
-            ),
-            None,
-        )
+        return self.get_website_url_for_type(UrlType.FACEBOOK)
 
     def get_twitter(self):
-        return next(
-            (
-                resolve_url(website.website_url)
-                for website in self.data.website_urls or []
-                if website.url_type == UrlType.TWITTER
-            ),
-            None,
-        )
+        return self.get_website_url_for_type(UrlType.TWITTER)
 
     def get_instagram(self):
-        return None
+        return self.get_website_url_for_type(UrlType.INSTAGRAM)
 
     def get_youtube(self):
         return None

--- a/tests/fixtures/orsay_museum.json
+++ b/tests/fixtures/orsay_museum.json
@@ -290,10 +290,6 @@
         "value": "https://www.instagram.com/MuseeOrsay"
     },
     {
-        "key": "contact:instagram",
-        "value": "https://www.instagram.com/MuseeOrsay"
-    },
-    {
         "key": "contact:youtube",
         "value": "https://www.youtube.com/MuseeOrsayOfficiel"
     },

--- a/tests/fixtures/orsay_museum.json
+++ b/tests/fixtures/orsay_museum.json
@@ -278,6 +278,26 @@
       "value": "+33140494814"
     },
     {
+        "key": "contact:facebook",
+        "value": "MuseeOrsay"
+    },
+    {
+        "key": "contact:twitter",
+        "value": "@MuseeOrsay"
+    },
+    {
+        "key": "contact:instagram",
+        "value": "https://www.instagram.com/MuseeOrsay"
+    },
+    {
+        "key": "contact:instagram",
+        "value": "https://www.instagram.com/MuseeOrsay"
+    },
+    {
+        "key": "contact:youtube",
+        "value": "https://www.youtube.com/MuseeOrsayOfficiel"
+    },
+    {
       "key": "name:it",
       "value": "Museo d'Orsay"
     },

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -92,6 +92,27 @@ def test_bbox():
                         "url": "http://www.musee-orsay.fr",
                         "label": "www.musee-orsay.fr",
                     },
+                    {
+                        "type": "social",
+                        "links": [
+                            {
+                                "site": "facebook",
+                                "url": "https://www.facebook.com/MuseeOrsay",
+                            },
+                            {
+                                "site": "twitter",
+                                "url": "https://twitter.com/MuseeOrsay",
+                            },
+                            {
+                                "site": "instagram",
+                                "url": "https://www.instagram.com/MuseeOrsay",
+                            },
+                            {
+                                "site": "youtube",
+                                "url": "https://www.youtube.com/MuseeOrsayOfficiel",
+                            },
+                        ],
+                    },
                 ],
                 "meta": {
                     "source": "osm",
@@ -302,6 +323,27 @@ def test_size_list():
                         "type": "website",
                         "url": "http://www.musee-orsay.fr",
                         "label": "www.musee-orsay.fr",
+                    },
+                    {
+                        "type": "social",
+                        "links": [
+                            {
+                                "site": "facebook",
+                                "url": "https://www.facebook.com/MuseeOrsay",
+                            },
+                            {
+                                "site": "twitter",
+                                "url": "https://twitter.com/MuseeOrsay",
+                            },
+                            {
+                                "site": "instagram",
+                                "url": "https://www.instagram.com/MuseeOrsay",
+                            },
+                            {
+                                "site": "youtube",
+                                "url": "https://www.youtube.com/MuseeOrsayOfficiel",
+                            },
+                        ],
                     },
                 ],
                 "meta": ANY,

--- a/tests/test_pj_poi.py
+++ b/tests/test_pj_poi.py
@@ -102,6 +102,7 @@ def test_pj_place(enable_pj_source):
 
     assert blocks[4]["type"] == "images"
     assert len(blocks[4]["images"]) == 3
+
     assert blocks[5]["type"] == "grades"
     assert blocks[5]["total_grades_count"] == 8
     assert blocks[5]["global_grade"] == 4.0
@@ -114,11 +115,21 @@ def test_pj_api_place(enable_pj_source):
     response = client.get(url="http://localhost/v1/places/pj:05360257?lang=fr")
     assert response.status_code == 200
     resp = response.json()
-
     blocks = resp["blocks"]
+
     assert blocks[6]["type"] == "transactional"
     assert blocks[6]["appointment_url"].startswith(
         "http://localhost:5000/v1/redirect?url=https%3A%2F%2F%5BAPPOINTMENT_URL%5D&hash=92710b"
+    )
+
+    assert blocks[7]["type"] == "social"
+    assert blocks[7]["links"][0]["site"] == "facebook"
+    assert blocks[7]["links"][0]["url"].startswith(
+        "http://localhost:5000/v1/redirect?url=https%3A%2F%2F%5BFACEBOOK%5D&hash=20eedf5"
+    )
+    assert blocks[7]["links"][1]["site"] == "twitter"
+    assert blocks[7]["links"][1]["url"].startswith(
+        "http://localhost:5000/v1/redirect?url=https%3A%2F%2F%5BTWITTER%5D&hash=c34074b"
     )
 
 

--- a/tests/test_pj_poi.py
+++ b/tests/test_pj_poi.py
@@ -117,6 +117,12 @@ def test_pj_api_place(enable_pj_source):
     resp = response.json()
     blocks = resp["blocks"]
 
+    assert blocks[3]["type"] == "website"
+    assert blocks[3]["url"].startswith(
+        "http://localhost:5000/v1/redirect?url=http%3A%2F%2Fwww.museepicassoparis.fr&hash=b6fc09"
+    )
+    assert blocks[3]["label"] == "www.museepicassoparis.fr"
+
     assert blocks[6]["type"] == "transactional"
     assert blocks[6]["appointment_url"].startswith(
         "http://localhost:5000/v1/redirect?url=https%3A%2F%2F%5BAPPOINTMENT_URL%5D&hash=92710b"

--- a/tests/test_places.py
+++ b/tests/test_places.py
@@ -359,6 +359,27 @@ def test_full_query_poi():
             ],
         },
         {"type": "website", "url": "http://www.musee-orsay.fr", "label": "www.musee-orsay.fr"},
+        {
+            "type": "social",
+            "links": [
+                {
+                    "site": "facebook",
+                    "url": "https://www.facebook.com/MuseeOrsay",
+                },
+                {
+                    "site": "twitter",
+                    "url": "https://twitter.com/MuseeOrsay",
+                },
+                {
+                    "site": "instagram",
+                    "url": "https://www.instagram.com/MuseeOrsay",
+                },
+                {
+                    "site": "youtube",
+                    "url": "https://www.youtube.com/MuseeOrsayOfficiel",
+                },
+            ],
+        },
     ]
 
 


### PR DESCRIPTION
This adds new links for facebook, twitter, instagram and youtube (this last one is not really a social network but it has consequent coverage on OSM). Additionally, Facebook links won't be used anymore as websites urls (previously as a fallback for OSM and depending on the order for PJ).

~~I couldn't find any example of PJ places with an Instagram link so I didn't include it here :/~~