### PR TITLE
pj_poi: add conversion to class for all categories supported by

### DIFF
--- a/idunn/places/pj_poi.py
+++ b/idunn/places/pj_poi.py
@@ -31,7 +31,6 @@ DOCTORS = (
     "Ophtalmologue",
     "Médecin généraliste",
     "Infirmier",
-    "kinésithérapeute",
     "Psychologue",
     "Ergothérapeute",
 )
@@ -45,7 +44,7 @@ def get_class_subclass(raw_categories):
         {"raw": "salles de cinéma", "class": "cinema"},
         {"raw": "salles de concerts, de spectacles", "class": "theatre"},
         {"raw": "Pharmacie", "class": "pharmacy"},
-        {"raw": "supermarchés, hypermarchés", "class": "grocery"},
+        {"raw": "supermarchés, hypermarchés", "class": "supermarket"},
         {"raw": "banques", "class": "bank"},
         {"raw": "cafés, bars", "class": "bar"},
         {"raw": "Chirurgien-dentiste", "class": "dentist"},
@@ -60,6 +59,16 @@ def get_class_subclass(raw_categories):
         {"raw": "piscines (établissements)", "class": "sports_centre"},
         {"raw": "clubs de sport", "class": "sports_centre"},
         {"raw": "vétérinaires", "class": "veterinary"},
+        {"raw": "Masseur kinésithérapeute", "class": "health_physiotherapist"},
+        {"raw": "restauration rapide", "class": "fast_food"},
+        {"raw": "boulangeries-pâtisseries (artisans)", "class": "bakery"},
+        {"raw": "coiffeurs", "class": "hairdresser"},
+        {
+            "class": "clothes",
+            "func": lambda raw_categories: any(
+                k in c for c in raw_categories for k in ("vêtements", "lingerie")
+            ),
+        },
         {
             "class": "school",
             "func": lambda raw_categories: any(

--- a/tests/test_pj_categories.py
+++ b/tests/test_pj_categories.py
@@ -27,8 +27,8 @@ def test_categories_pj():
     assert poi.get_subclass_name() == "pharmacy"
 
     poi = PjPOI({"Category": ["supermarchés, hypermarchés"]})
-    assert poi.get_class_name() == "grocery"
-    assert poi.get_subclass_name() == "grocery"
+    assert poi.get_class_name() == "supermarket"
+    assert poi.get_subclass_name() == "supermarket"
 
     poi = PjPOI({"Category": ["banques"]})
     assert poi.get_class_name() == "bank"


### PR DESCRIPTION
All categories results from pagesjaunes should now have a specified class, this allows erdapfel to [identify what to display as a category](https://github.com/Qwant/erdapfel/blob/master/local_modules/qwant-maps-common/src/place_category_name.js).

There may still be some POIs for which we display no categories, especially when performing a full-text search which is triggered when the tagger detects a brand intention).

Note that all the added classes are already recognized by erdapfel (even though I managed to break that while I was investigating on how erdapfel delt with this ... :roll_eyes:).