### PR TITLE
Add source `wiki_es`

### DIFF
--- a/idunn/blocks/__init__.py
+++ b/idunn/blocks/__init__.py
@@ -6,11 +6,7 @@ from .phone import PhoneBlock
 from .information import InformationBlock
 from .website import WebSiteBlock
 from .contact import ContactBlock
-from .wikipedia import (
-    WikipediaBlock,
-    WikiUndefinedException,
-    GET_WIKI_INFO,
-)
+from .wikipedia import WikipediaBlock, GET_WIKI_INFO
 from .images import ImagesBlock
 from .services_and_information import (
     ServicesAndInformationBlock,
@@ -20,16 +16,8 @@ from .services_and_information import (
     CuisineBlock,
 )
 from .grades import GradesBlock
-from .events import (
-    OpeningDayEvent,
-    DescriptionEvent,
-)
-
-from .environment import (
-    AirQuality,
-    Weather,
-)
-
+from .events import OpeningDayEvent, DescriptionEvent
+from .environment import AirQuality, Weather
 from .recycling import RecyclingBlock
 from .transactional import TransactionalBlock
 from .social import SocialBlock

--- a/idunn/blocks/wikipedia.py
+++ b/idunn/blocks/wikipedia.py
@@ -153,15 +153,10 @@ class WikipediaBlock(BaseBlock):
 
     @classmethod
     def from_es(cls, place, lang):
-        """
-        If "wikidata_id" is present and "lang" is in "ES_WIKI_LANG",
-        then we try to fetch our "WIKI_ES" (if WIKI_ES has been defined),
-        else then we fetch the wikipedia API.
-        """
-        wikidata_id = place.wikidata_id
-
-        if wikidata_id is not None and wiki_es.enabled() and wiki_es.is_lang_available(lang):
-            wiki_poi_info = wiki_es.get_info(wikidata_id, lang)
+        # If `wikidata_id` is present and `lang` is available in `wiki_es`, try
+        # to fetch from ES, otherwise we fetch the wikipedia API.
+        if place.wikidata_id is not None and wiki_es.enabled() and wiki_es.is_lang_available(lang):
+            wiki_poi_info = wiki_es.get_info(place.wikidata_id, lang)
 
             if wiki_poi_info is None:
                 return None

--- a/idunn/blocks/wikipedia.py
+++ b/idunn/blocks/wikipedia.py
@@ -6,6 +6,7 @@ from redis import RedisError
 from typing import ClassVar, Literal
 
 from idunn import settings
+from idunn.datasources.wikidata import wikidata_es
 from idunn.utils import prometheus
 from idunn.utils.redis import RedisWrapper
 from idunn.utils.circuit_breaker import IdunnCircuitBreaker
@@ -18,10 +19,6 @@ GET_TITLE_IN_LANGUAGE = "get_title_in_language"
 GET_SUMMARY = "get_summary"
 
 logger = logging.getLogger(__name__)
-
-
-class WikiUndefinedException(Exception):
-    pass
 
 
 class WikipediaSession:
@@ -162,23 +159,22 @@ class WikipediaBlock(BaseBlock):
         else then we fetch the wikipedia API.
         """
         wikidata_id = place.wikidata_id
-        if wikidata_id is not None:
-            wiki_index = place.get_wiki_index(lang)
-            if wiki_index is not None:
-                try:
-                    key = GET_WIKI_INFO + "_" + wikidata_id + "_" + lang + "_" + wiki_index
-                    wiki_poi_info = RedisWrapper.cache_it(key, place.get_wiki_info)(
-                        wikidata_id, wiki_index
-                    )
-                    if wiki_poi_info is not None:
-                        return cls(
-                            url=wiki_poi_info.get("url"),
-                            title=wiki_poi_info.get("title")[0],
-                            description=SizeLimiter.limit_size(wiki_poi_info.get("content", "")),
-                        )
-                    return None
-                except WikiUndefinedException:
-                    logger.info("WIKI_ES variable has not been set: call to Wikipedia")
+
+        if (
+            wikidata_id is not None
+            and wikidata_es.enabled()
+            and wikidata_es.is_lang_available(lang)
+        ):
+            wiki_poi_info = wikidata_es.get_info(wikidata_id, lang)
+
+            if wiki_poi_info is None:
+                return None
+
+            return cls(
+                url=wiki_poi_info.get("url"),
+                title=wiki_poi_info.get("title")[0],
+                description=SizeLimiter.limit_size(wiki_poi_info.get("content", "")),
+            )
 
         wikipedia_value = place.properties.get("wikipedia")
         wiki_title = None

--- a/idunn/blocks/wikipedia.py
+++ b/idunn/blocks/wikipedia.py
@@ -6,7 +6,7 @@ from redis import RedisError
 from typing import ClassVar, Literal
 
 from idunn import settings
-from idunn.datasources.wikidata import wikidata_es
+from idunn.datasources.wiki_es import wiki_es
 from idunn.utils import prometheus
 from idunn.utils.redis import RedisWrapper
 from idunn.utils.circuit_breaker import IdunnCircuitBreaker
@@ -160,12 +160,8 @@ class WikipediaBlock(BaseBlock):
         """
         wikidata_id = place.wikidata_id
 
-        if (
-            wikidata_id is not None
-            and wikidata_es.enabled()
-            and wikidata_es.is_lang_available(lang)
-        ):
-            wiki_poi_info = wikidata_es.get_info(wikidata_id, lang)
+        if wikidata_id is not None and wiki_es.enabled() and wiki_es.is_lang_available(lang):
+            wiki_poi_info = wiki_es.get_info(wikidata_id, lang)
 
             if wiki_poi_info is None:
                 return None

--- a/idunn/datasources/wiki_es.py
+++ b/idunn/datasources/wiki_es.py
@@ -52,12 +52,7 @@ class WikiEs:
         return None
 
     def get_info(self, wikidata_id, lang):
-        if not self.enabled():
-            logger.warning("Wiki ES is disabled %s", lang)
-            return None
-
-        if not self.is_lang_available(lang):
-            logger.warning("Wiki ES does not support lang %s", lang)
+        if not self.enabled() or not self.is_lang_available(lang):
             return None
 
         es_index = self.get_index(lang)

--- a/idunn/datasources/wiki_es.py
+++ b/idunn/datasources/wiki_es.py
@@ -13,7 +13,14 @@ from idunn.utils.redis import RedisWrapper
 logger = logging.getLogger(__name__)
 
 
-class WikidataEs:
+class WikiEs:
+    """
+    Handle on an internal ElasticSearch populated with Wikipedia data.
+
+    Note that the indexes are named f"wikidata_{lang}", but they still contain
+    data from Wikipedia.
+    """
+
     REDIS_INFO_KEY_PREFIX = "get_wiki_info"
 
     def __init__(self):
@@ -95,4 +102,4 @@ class WikidataEs:
         return fetch_data_cached()
 
 
-wikidata_es = WikidataEs()
+wiki_es = WikiEs()

--- a/idunn/datasources/wikidata.py
+++ b/idunn/datasources/wikidata.py
@@ -1,0 +1,98 @@
+from elasticsearch import (
+    Elasticsearch,
+    ConnectionError,
+    NotFoundError,
+    ElasticsearchException,
+)
+import logging
+from idunn import settings
+from idunn.utils import prometheus
+from idunn.utils.redis import RedisWrapper
+
+
+logger = logging.getLogger(__name__)
+
+
+class WikidataEs:
+    REDIS_INFO_KEY_PREFIX = "get_wiki_info"
+
+    def __init__(self):
+        wiki_es_url = settings.get("WIKI_ES")
+        wiki_es_max_retries = settings.get("WIKI_ES_MAX_RETRIES")
+        wiki_es_timeout = settings.get("WIKI_ES_TIMEOUT")
+
+        if wiki_es_url is None:
+            self.es = None
+            return
+
+        self.es = Elasticsearch(
+            wiki_es_url,
+            max_retries=wiki_es_max_retries,
+            timeout=wiki_es_timeout,
+        )
+
+    def enabled(self):
+        return self.es is not None
+
+    @classmethod
+    def is_lang_available(cls, lang):
+        return lang in settings["ES_WIKI_LANG"].split(",")
+
+    @classmethod
+    def get_index(cls, lang):
+        if cls.is_lang_available(lang):
+            return "wikidata_{}".format(lang)
+        return None
+
+    def get_info(self, wikidata_id, lang):
+        if not self.enabled():
+            logger.warning("Wiki ES is disabled %s", lang)
+            return None
+
+        if not self.is_lang_available(lang):
+            logger.warning("Wiki ES does not support lang %s", lang)
+            return None
+
+        es_index = self.get_index(lang)
+
+        def fetch_data():
+            try:
+                with prometheus.wiki_request_duration("wiki_es", "get_wiki_info"):
+                    resp = (
+                        self.es.search(
+                            index=es_index,
+                            body={
+                                "query": {
+                                    "bool": {"filter": {"term": {"wikibase_item": wikidata_id}}}
+                                }
+                            },
+                        )
+                        .get("hits", {})
+                        .get("hits", [])
+                    )
+            except ConnectionError:
+                logger.warning("Wiki ES not available: connection exception raised", exc_info=True)
+                return None
+            except NotFoundError:
+                logger.warning(
+                    "Wiki ES didn't find wikidata_id '%s' in wiki_index '%s'",
+                    wikidata_id,
+                    es_index,
+                    exc_info=True,
+                )
+                return None
+            except ElasticsearchException:
+                logger.warning("Wiki ES failure: unknown elastic error", exc_info=True)
+                return None
+
+            if not resp:
+                return None
+
+            return resp[0].get("_source")
+
+        redis_key = self.REDIS_INFO_KEY_PREFIX + "_" + wikidata_id + "_" + lang + "_" + es_index
+        fetch_data_cached = RedisWrapper.cache_it(redis_key, fetch_data)
+        return fetch_data_cached()
+
+
+wikidata_es = WikidataEs()

--- a/idunn/places/base.py
+++ b/idunn/places/base.py
@@ -33,25 +33,18 @@ class BasePlace(dict):
         self._wiki_resp = {}
         self.properties = {}
 
-    def get_wiki_info(self, wikidata_id, lang):
-        return wiki_es.get_info(wikidata_id, lang)
-
-    def get_wiki_index(self, lang):
-        return wiki_es.get_index(lang)
+    @property
+    def wikidata_id(self):
+        return self.properties.get("wikidata")
 
     def get_wiki_resp(self, lang):
         if lang not in self._wiki_resp:
             self._wiki_resp[lang] = None
-            wikidata_id = self.wikidata_id
 
-            if wikidata_id is not None:
-                self._wiki_resp[lang] = wiki_es.get_info(wikidata_id, lang)
+            if self.wikidata_id is not None:
+                self._wiki_resp[lang] = wiki_es.get_info(self.wikidata_id, lang)
 
         return self._wiki_resp.get(lang)
-
-    @property
-    def wikidata_id(self):
-        return self.properties.get("wikidata")
 
     def get_name(self, _lang):
         return self.get_local_name()

--- a/idunn/places/base.py
+++ b/idunn/places/base.py
@@ -4,7 +4,7 @@ from geopy import Point
 from pytz import timezone, UTC
 
 from idunn.api.utils import Verbosity, build_blocks
-from idunn.datasources.wikidata import wikidata_es
+from idunn.datasources.wiki_es import wiki_es
 from idunn.utils import maps_urls, tz
 from .place import Place, PlaceMeta
 
@@ -34,10 +34,10 @@ class BasePlace(dict):
         self.properties = {}
 
     def get_wiki_info(self, wikidata_id, lang):
-        return wikidata_es.get_info(wikidata_id, lang)
+        return wiki_es.get_info(wikidata_id, lang)
 
     def get_wiki_index(self, lang):
-        return wikidata_es.get_index(lang)
+        return wiki_es.get_index(lang)
 
     def get_wiki_resp(self, lang):
         if lang not in self._wiki_resp:
@@ -45,7 +45,7 @@ class BasePlace(dict):
             wikidata_id = self.wikidata_id
 
             if wikidata_id is not None:
-                self._wiki_resp[lang] = wikidata_es.get_info(wikidata_id, lang)
+                self._wiki_resp[lang] = wiki_es.get_info(wikidata_id, lang)
 
         return self._wiki_resp.get(lang)
 

--- a/idunn/places/base.py
+++ b/idunn/places/base.py
@@ -3,9 +3,8 @@ import re
 from geopy import Point
 from pytz import timezone, UTC
 
-from idunn.api.utils import Verbosity, WikidataConnector, build_blocks
-from idunn.blocks import WikiUndefinedException, GET_WIKI_INFO
-from idunn.utils.redis import RedisWrapper
+from idunn.api.utils import Verbosity, build_blocks
+from idunn.datasources.wikidata import wikidata_es
 from idunn.utils import maps_urls, tz
 from .place import Place, PlaceMeta
 
@@ -34,29 +33,20 @@ class BasePlace(dict):
         self._wiki_resp = {}
         self.properties = {}
 
-    def get_wiki_info(self, wikidata_id, wiki_index):
-        return WikidataConnector.get_wiki_info(wikidata_id, wiki_index)
+    def get_wiki_info(self, wikidata_id, lang):
+        return wikidata_es.get_info(wikidata_id, lang)
 
     def get_wiki_index(self, lang):
-        return WikidataConnector.get_wiki_index(lang)
+        return wikidata_es.get_index(lang)
 
     def get_wiki_resp(self, lang):
         if lang not in self._wiki_resp:
             self._wiki_resp[lang] = None
             wikidata_id = self.wikidata_id
+
             if wikidata_id is not None:
-                wiki_index = self.get_wiki_index(lang)
-                if wiki_index is not None:
-                    key = GET_WIKI_INFO + "_" + wikidata_id + "_" + lang + "_" + wiki_index
-                    try:
-                        self._wiki_resp[lang] = RedisWrapper.cache_it(
-                            key, WikidataConnector.get_wiki_info
-                        )(wikidata_id, wiki_index)
-                    except WikiUndefinedException:
-                        logger.info(
-                            "WIKI_ES variable has not been set: cannot fetch wikidata images"
-                        )
-                        return None
+                self._wiki_resp[lang] = wikidata_es.get_info(wikidata_id, lang)
+
         return self._wiki_resp.get(lang)
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 import respx
 from elasticsearch import Elasticsearch
 
-from .utils import override_settings
+from .utils import init_wikidata_es, override_settings
 
 
 @pytest.fixture(scope="session")
@@ -31,7 +31,7 @@ def wiki_es(docker_services):
     port = docker_services.wait_for_service("wiki_es", 9200)
     url = f"http://{docker_services.docker_ip}:{port}"
 
-    with override_settings({"WIKI_ES": url, "ES_WIKI_LANG": "fr"}):
+    with override_settings({"WIKI_ES": url, "ES_WIKI_LANG": "fr"}), init_wikidata_es():
         yield url
 
 
@@ -45,8 +45,14 @@ def wiki_es_ko(docker_services):
     docker_services.wait_for_service("wiki_es", 9200)
     url = "something.invalid:1234"
 
-    with override_settings({"WIKI_ES": url, "ES_WIKI_LANG": "fr"}):
+    with override_settings({"WIKI_ES": url, "ES_WIKI_LANG": "fr"}), init_wikidata_es():
         yield url
+
+
+@pytest.fixture(scope="function")
+def wiki_es_undefined():
+    with override_settings({"WIKI_ES": None}), init_wikidata_es():
+        yield
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 import respx
 from elasticsearch import Elasticsearch
 
-from .utils import init_wikidata_es, override_settings
+from .utils import init_wiki_es, override_settings
 
 
 @pytest.fixture(scope="session")
@@ -31,7 +31,7 @@ def wiki_es(docker_services):
     port = docker_services.wait_for_service("wiki_es", 9200)
     url = f"http://{docker_services.docker_ip}:{port}"
 
-    with override_settings({"WIKI_ES": url, "ES_WIKI_LANG": "fr"}), init_wikidata_es():
+    with override_settings({"WIKI_ES": url, "ES_WIKI_LANG": "fr"}), init_wiki_es():
         yield url
 
 
@@ -45,13 +45,13 @@ def wiki_es_ko(docker_services):
     docker_services.wait_for_service("wiki_es", 9200)
     url = "something.invalid:1234"
 
-    with override_settings({"WIKI_ES": url, "ES_WIKI_LANG": "fr"}), init_wikidata_es():
+    with override_settings({"WIKI_ES": url, "ES_WIKI_LANG": "fr"}), init_wiki_es():
         yield url
 
 
 @pytest.fixture(scope="function")
 def wiki_es_undefined():
-    with override_settings({"WIKI_ES": None}), init_wikidata_es():
+    with override_settings({"WIKI_ES": None}), init_wiki_es():
         yield
 
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -76,10 +76,10 @@ def test_wikidata_cache(cache_test_normal, basket_ball_wiki_es, monkeypatch):
             #
             # So we change the method used by the WikidataConnector by a fake
             # method to be sure the real method is not called.
-            from idunn.api.utils import WikidataConnector
+            from idunn.datasources.wikidata import wikidata_es
 
-            @wraps(WikidataConnector.get_wiki_info)
-            def fake_get_wiki_info():
+            @wraps(wikidata_es.get_info)
+            def fake_get_info():
                 """
                 Fake method for test
 
@@ -87,7 +87,7 @@ def test_wikidata_cache(cache_test_normal, basket_ball_wiki_es, monkeypatch):
                 """
                 raise Exception
 
-            m.setattr(WikidataConnector, "get_wiki_info", fake_get_wiki_info)
+            m.setattr(wikidata_es, "get_info", fake_get_info)
 
             # We make 10 requests to the basket_ball POI and we should still
             # have the wikipedia block in the answer but without call to

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -76,9 +76,9 @@ def test_wikidata_cache(cache_test_normal, basket_ball_wiki_es, monkeypatch):
             #
             # So we change the method used by the WikidataConnector by a fake
             # method to be sure the real method is not called.
-            from idunn.datasources.wikidata import wikidata_es
+            from idunn.datasources.wiki_es import wiki_es
 
-            @wraps(wikidata_es.get_info)
+            @wraps(wiki_es.get_info)
             def fake_get_info():
                 """
                 Fake method for test
@@ -87,7 +87,7 @@ def test_wikidata_cache(cache_test_normal, basket_ball_wiki_es, monkeypatch):
                 """
                 raise Exception
 
-            m.setattr(wikidata_es, "get_info", fake_get_info)
+            m.setattr(wiki_es, "get_info", fake_get_info)
 
             # We make 10 requests to the basket_ball POI and we should still
             # have the wikipedia block in the answer but without call to

--- a/tests/test_wiki_ES.py
+++ b/tests/test_wiki_ES.py
@@ -6,7 +6,10 @@ import re
 import json
 import responses
 
+
 from app import app, settings
+from .utils import init_wikidata_es, override_settings
+from .conftest import wiki_es_undefined
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -103,19 +106,8 @@ def test_WIKI_ES_KO(wiki_client_ko):
         assert all(b["type"] != "wikipedia" for b in resp["blocks"][2].get("blocks"))
 
 
-@pytest.fixture(scope="function")
-def undefine_wiki_es():
-    from idunn.api.utils import WikidataConnector
-
-    WikidataConnector._wiki_es = None
-    wiki_es_ip = settings["WIKI_ES"]
-    settings._settings["WIKI_ES"] = None
-    yield
-    settings._settings["WIKI_ES"] = wiki_es_ip  # put back the correct ip for next tests
-
-
 @freeze_time("2018-06-14 8:30:00", tz_offset=2)
-def test_undefined_WIKI_ES(undefine_wiki_es):
+def test_undefined_WIKI_ES(wiki_es_undefined):
     """
     Check that when the WIKI_ES variable is not set
     a Wikipedia call is observed

--- a/tests/test_wiki_ES.py
+++ b/tests/test_wiki_ES.py
@@ -8,7 +8,7 @@ import responses
 
 
 from app import app, settings
-from .utils import init_wikidata_es, override_settings
+from .utils import init_wiki_es, override_settings
 from .conftest import wiki_es_undefined
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,9 +3,11 @@ import json
 from contextlib import contextmanager
 from copy import deepcopy
 
+import idunn
 from idunn import settings
 from idunn.api import places_list, instant_answer
 from idunn.datasources.recycling import recycling_client
+from idunn.datasources.wikidata import WikidataEs
 from idunn.places import utils as places_utils
 
 
@@ -20,6 +22,19 @@ def override_settings(overrides):
         yield
     finally:
         settings._settings = old_settings
+
+
+@contextmanager
+def init_wikidata_es():
+    old_es = idunn.blocks.wikipedia.wikidata_es
+    idunn.blocks.wikipedia.wikidata_es = WikidataEs()
+    idunn.places.base.wikidata_es = WikidataEs()
+
+    try:
+        yield
+    finally:
+        idunn.blocks.wikipedia.wikidata_es = old_es
+        idunn.places.base.wikidata_es = old_es
 
 
 @contextmanager

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,7 +7,7 @@ import idunn
 from idunn import settings
 from idunn.api import places_list, instant_answer
 from idunn.datasources.recycling import recycling_client
-from idunn.datasources.wikidata import WikidataEs
+from idunn.datasources.wiki_es import WikiEs
 from idunn.places import utils as places_utils
 
 
@@ -25,16 +25,16 @@ def override_settings(overrides):
 
 
 @contextmanager
-def init_wikidata_es():
-    old_es = idunn.blocks.wikipedia.wikidata_es
-    idunn.blocks.wikipedia.wikidata_es = WikidataEs()
-    idunn.places.base.wikidata_es = WikidataEs()
+def init_wiki_es():
+    old_es = idunn.blocks.wikipedia.wiki_es
+    idunn.blocks.wikipedia.wiki_es = WikiEs()
+    idunn.places.base.wiki_es = WikiEs()
 
     try:
         yield
     finally:
-        idunn.blocks.wikipedia.wikidata_es = old_es
-        idunn.places.base.wikidata_es = old_es
+        idunn.blocks.wikipedia.wiki_es = old_es
+        idunn.places.base.wiki_es = old_es
 
 
 @contextmanager


### PR DESCRIPTION
Reorganize calls to the Wikipedia API to move most logic in `datasources/`, this was also an opportunity to de-duplicate the calls to Redis cache.