### PR TITLE
move wikipedia wrapper into its own source

### DIFF
--- a/idunn/blocks/__init__.py
+++ b/idunn/blocks/__init__.py
@@ -6,7 +6,7 @@ from .phone import PhoneBlock
 from .information import InformationBlock
 from .website import WebSiteBlock
 from .contact import ContactBlock
-from .wikipedia import WikipediaBlock, GET_WIKI_INFO
+from .wikipedia import WikipediaBlock
 from .images import ImagesBlock
 from .services_and_information import (
     ServicesAndInformationBlock,

--- a/idunn/blocks/wikipedia.py
+++ b/idunn/blocks/wikipedia.py
@@ -1,160 +1,35 @@
 import logging
-import requests
-import pybreaker
-from requests.exceptions import HTTPError, RequestException, Timeout
-from redis import RedisError
-from typing import ClassVar, Literal
+from typing import Literal
 
 from idunn import settings
 from idunn.datasources.wiki_es import wiki_es
-from idunn.utils import prometheus
-from idunn.utils.redis import RedisWrapper
-from idunn.utils.circuit_breaker import IdunnCircuitBreaker
-from idunn.utils.rate_limiter import IdunnRateLimiter, TooManyRequestsException
+from idunn.datasources.wikipedia import wikipedia_session
 from .base import BaseBlock
 
-
-GET_WIKI_INFO = "get_wiki_info"
-GET_TITLE_IN_LANGUAGE = "get_title_in_language"
-GET_SUMMARY = "get_summary"
 
 logger = logging.getLogger(__name__)
 
 
-class WikipediaSession:
-    _session = None
-    _rate_limiter = None
-    timeout = 1.0  # seconds
+def limit_size(content: str) -> str:
+    wiki_desc_max_size = int(settings["WIKI_DESC_MAX_SIZE"])
 
-    API_V1_BASE_PATTERN = "https://{lang}.wikipedia.org/api/rest_v1"
-    API_PHP_BASE_PATTERN = "https://{lang}.wikipedia.org/w/api.php"
+    if len(content) > wiki_desc_max_size:
+        return content[:wiki_desc_max_size] + "…"
 
-    circuit_breaker = IdunnCircuitBreaker(
-        "wikipedia_api_breaker",
-        int(settings["WIKI_BREAKER_MAXFAIL"]),
-        int(settings["WIKI_BREAKER_TIMEOUT"]),
-    )
-
-    class Helpers:
-        @staticmethod
-        def handle_requests_error(f):
-            def wrapped_f(*args, **kwargs):
-                try:
-                    with WikipediaSession.get_rate_limiter().limit(client="idunn"):
-                        return f(*args, **kwargs)
-                except pybreaker.CircuitBreakerError:
-                    prometheus.exception("CircuitBreakerError")
-                    logger.error(
-                        "Got CircuitBreakerError in %s",
-                        f.__name__,
-                        exc_info=True,
-                    )
-                except HTTPError:
-                    prometheus.exception("HTTPError")
-                    logger.warning("Got HTTP error in %s", f.__name__, exc_info=True)
-                except Timeout:
-                    prometheus.exception("RequestsTimeout")
-                    logger.warning("External API timed out in %s", f.__name__, exc_info=True)
-                except RequestException:
-                    prometheus.exception("RequestException")
-                    logger.error("Got Request exception in %s", f.__name__, exc_info=True)
-                except TooManyRequestsException:
-                    prometheus.exception("TooManyRequests")
-                    logger.warning("Got TooManyRequests in %s", f.__name__, exc_info=True)
-                except RedisError:
-                    prometheus.exception("RedisError")
-                    logger.warning("Got redis ConnectionError in %s", f.__name__, exc_info=True)
-                return None
-
-            return wrapped_f
-
-    @property
-    def session(self):
-        if self._session is None:
-            user_agent = settings["WIKI_USER_AGENT"]
-            self._session = requests.Session()
-            self._session.headers.update({"User-Agent": user_agent})
-        return self._session
-
-    @classmethod
-    def get_rate_limiter(cls):
-        if cls._rate_limiter is None:
-            cls._rate_limiter = IdunnRateLimiter(
-                resource="WikipediaAPI",
-                max_requests=int(settings["WIKI_API_RL_MAX_CALLS"]),
-                expire=int(settings["WIKI_API_RL_PERIOD"]),
-            )
-        return cls._rate_limiter
-
-    @Helpers.handle_requests_error
-    @circuit_breaker
-    def get_summary(self, title, lang):
-        url = "{base_url}/page/summary/{title}".format(
-            base_url=self.API_V1_BASE_PATTERN.format(lang=lang), title=title
-        )
-
-        with prometheus.wiki_request_duration("wiki_api", "get_summary"):
-            resp = self.session.get(url=url, params={"redirect": True}, timeout=self.timeout)
-
-        resp.raise_for_status()
-        return resp.json()
-
-    @Helpers.handle_requests_error
-    @circuit_breaker
-    def get_title_in_language(self, title, source_lang, dest_lang):
-        url = self.API_PHP_BASE_PATTERN.format(lang=source_lang)
-
-        with prometheus.wiki_request_duration("wiki_api", "get_title"):
-            resp = self.session.get(
-                url=url,
-                params={
-                    "action": "query",
-                    "prop": "langlinks",
-                    "titles": title,
-                    "lllang": dest_lang,
-                    "formatversion": 2,
-                    "format": "json",
-                },
-                timeout=self.timeout,
-            )
-
-        resp.raise_for_status()
-        resp_data = resp.json()
-        resp_pages = resp_data.get("query", {}).get("pages", [])
-        if len(resp_pages) > 0:
-            if len(resp_pages) > 1:
-                logger.warning("Got multiple pages in wikipedia langlinks response: %s", resp_data)
-            lang_links = resp_pages[0].get("langlinks", [])
-            if len(lang_links) > 0:
-                return lang_links[0].get("title")
-
-        return None
+    return content
 
 
-class SizeLimiter:
-    @classmethod
-    def limit_size(cls, content):
-        """
-        Just cut a string if its length > max_size
-        """
-        max_wiki_desc_size = settings["WIKI_DESC_MAX_SIZE"]
-        return (
-            (content[:max_wiki_desc_size] + "...") if len(content) > max_wiki_desc_size else content
-        )
-
-
+# TODO: this block should not be used, the block `description` is instead favored.
 class WikipediaBlock(BaseBlock):
     type: Literal["wikipedia"] = "wikipedia"
     url: str
     title: str
     description: str
 
-    _wiki_session: ClassVar = WikipediaSession()
-
     @classmethod
     def from_es(cls, place, lang):
         # If `wikidata_id` is present and `lang` is available in `wiki_es`, try
-        # to fetch from ES, otherwise we fetch the wikipedia API.
+        # to fetch from ES.
         if place.wikidata_id is not None and wiki_es.enabled() and wiki_es.is_lang_available(lang):
             wiki_poi_info = wiki_es.get_info(place.wikidata_id, lang)
 
@@ -164,33 +39,37 @@ class WikipediaBlock(BaseBlock):
             return cls(
                 url=wiki_poi_info.get("url"),
                 title=wiki_poi_info.get("title")[0],
-                description=SizeLimiter.limit_size(wiki_poi_info.get("content", "")),
+                description=limit_size(wiki_poi_info.get("content", "")),
             )
 
+        # Overwise, fetch summary from Wikipedia API
         wikipedia_value = place.properties.get("wikipedia")
         wiki_title = None
 
-        if wikipedia_value:
-            wiki_split = wikipedia_value.split(":", maxsplit=1)
-            if len(wiki_split) == 2:
-                wiki_lang, wiki_title = wiki_split
-                wiki_lang = wiki_lang.lower()
-                if wiki_lang != lang:
-                    key = GET_TITLE_IN_LANGUAGE + "_" + wiki_title + "_" + wiki_lang + "_" + lang
-                    wiki_title = RedisWrapper.cache_it(
-                        key, cls._wiki_session.get_title_in_language
-                    )(title=wiki_title, source_lang=wiki_lang, dest_lang=lang)
+        if not wikipedia_value:
+            return None
 
-        if wiki_title:
-            key = GET_SUMMARY + "_" + wiki_title + "_" + lang
-            wiki_summary = RedisWrapper.cache_it(key, cls._wiki_session.get_summary)(
-                wiki_title, lang=lang
-            )
-            if wiki_summary:
-                return cls(
-                    url=wiki_summary.get("content_urls", {}).get("desktop", {}).get("page", ""),
-                    title=wiki_summary.get("displaytitle", ""),
-                    description=SizeLimiter.limit_size(wiki_summary.get("extract", "")),
-                )
+        wiki_split = wikipedia_value.split(":", maxsplit=1)
 
-        return None
+        if len(wiki_split) != 2:
+            return None
+
+        wiki_lang, wiki_title = wiki_split
+        wiki_lang = wiki_lang.lower()
+
+        if wiki_lang != lang:
+            wiki_title = wikipedia_session.get_title_in_language(wiki_title, wiki_lang, lang)
+
+        if not wiki_title:
+            return None
+
+        wiki_summary = wikipedia_session.get_summary(wiki_title, lang)
+
+        if not wiki_summary:
+            return None
+
+        return cls(
+            url=wiki_summary.get("content_urls", {}).get("desktop", {}).get("page", ""),
+            title=wiki_summary.get("displaytitle", ""),
+            description=limit_size(wiki_summary.get("extract", "")),
+        )

--- a/idunn/datasources/wikipedia.py
+++ b/idunn/datasources/wikipedia.py
@@ -1,0 +1,145 @@
+import logging
+import requests
+import pybreaker
+from requests.exceptions import HTTPError, RequestException, Timeout
+from redis import RedisError
+
+from idunn import settings
+from idunn.utils import prometheus
+from idunn.utils.redis import RedisWrapper
+from idunn.utils.circuit_breaker import IdunnCircuitBreaker
+from idunn.utils.rate_limiter import IdunnRateLimiter, TooManyRequestsException
+
+
+logger = logging.getLogger(__name__)
+
+
+class WikipediaSession:
+    TIMEOUT = 1.0  # seconds
+
+    API_V1_BASE_PATTERN = "https://{lang}.wikipedia.org/api/rest_v1"
+    API_PHP_BASE_PATTERN = "https://{lang}.wikipedia.org/w/api.php"
+
+    REDIS_GET_SUMMARY_PREFIX = "get_summary"
+    REDIS_TITLE_IN_LANG_PREFIX = "get_title_in_language"
+
+    circuit_breaker = IdunnCircuitBreaker(
+        "wikipedia_api_breaker",
+        int(settings["WIKI_BREAKER_MAXFAIL"]),
+        int(settings["WIKI_BREAKER_TIMEOUT"]),
+    )
+
+    class Helpers:
+        _rate_limiter = None
+
+        @classmethod
+        def get_rate_limiter(cls):
+            if cls._rate_limiter is None:
+                cls._rate_limiter = IdunnRateLimiter(
+                    resource="WikipediaAPI",
+                    max_requests=int(settings["WIKI_API_RL_MAX_CALLS"]),
+                    expire=int(settings["WIKI_API_RL_PERIOD"]),
+                )
+
+            return cls._rate_limiter
+
+        @classmethod
+        def handle_requests_error(cls, f):
+            """
+            Helper function to catch exceptions and log them into Prometheus.
+            """
+
+            def wrapped_f(*args, **kwargs):
+                try:
+                    with cls.get_rate_limiter().limit(client="idunn"):
+                        return f(*args, **kwargs)
+                except pybreaker.CircuitBreakerError:
+                    prometheus.exception("CircuitBreakerError")
+                    logger.error(
+                        "Got CircuitBreakerError in %s",
+                        f.__name__,
+                        exc_info=True,
+                    )
+                except HTTPError:
+                    prometheus.exception("HTTPError")
+                    logger.warning("Got HTTP error in %s", f.__name__, exc_info=True)
+                except Timeout:
+                    prometheus.exception("RequestsTimeout")
+                    logger.warning("External API timed out in %s", f.__name__, exc_info=True)
+                except RequestException:
+                    prometheus.exception("RequestException")
+                    logger.error("Got Request exception in %s", f.__name__, exc_info=True)
+                except TooManyRequestsException:
+                    prometheus.exception("TooManyRequests")
+                    logger.warning("Got TooManyRequests in %s", f.__name__, exc_info=True)
+                except RedisError:
+                    prometheus.exception("RedisError")
+                    logger.warning("Got redis ConnectionError in %s", f.__name__, exc_info=True)
+                return None
+
+            return wrapped_f
+
+    def __init__(self):
+        self.session = requests.Session()
+        self.session.headers.update({"User-Agent": settings["WIKI_USER_AGENT"]})
+
+    def get_summary(self, title, lang):
+        @self.Helpers.handle_requests_error
+        @self.circuit_breaker
+        def fetch_data():
+            url = "{base_url}/page/summary/{title}".format(
+                base_url=self.API_V1_BASE_PATTERN.format(lang=lang),
+                title=title,
+            )
+
+            with prometheus.wiki_request_duration("wiki_api", "get_summary"):
+                resp = self.session.get(url=url, params={"redirect": True}, timeout=self.TIMEOUT)
+
+            resp.raise_for_status()
+            return resp.json()
+
+        key = self.REDIS_GET_SUMMARY_PREFIX + "_" + title + "_" + lang
+        fetch_data_cached = RedisWrapper.cache_it(key, fetch_data)
+        return fetch_data_cached()
+
+    def get_title_in_language(self, title, source_lang, dest_lang):
+        @self.Helpers.handle_requests_error
+        @self.circuit_breaker
+        def fetch_data():
+            url = self.API_PHP_BASE_PATTERN.format(lang=source_lang)
+
+            with prometheus.wiki_request_duration("wiki_api", "get_title"):
+                resp = self.session.get(
+                    url=url,
+                    params={
+                        "action": "query",
+                        "prop": "langlinks",
+                        "titles": title,
+                        "lllang": dest_lang,
+                        "formatversion": 2,
+                        "format": "json",
+                    },
+                    timeout=self.TIMEOUT,
+                )
+
+            resp.raise_for_status()
+            resp_data = resp.json()
+            resp_pages = resp_data.get("query", {}).get("pages", [])
+
+            if len(resp_pages) > 0:
+                if len(resp_pages) > 1:
+                    logger.warning(
+                        "Got multiple pages in wikipedia langlinks response: %s", resp_data
+                    )
+                lang_links = resp_pages[0].get("langlinks", [])
+                if len(lang_links) > 0:
+                    return lang_links[0].get("title")
+
+            return None
+
+        key = self.REDIS_TITLE_IN_LANG_PREFIX + "_" + title + "_" + source_lang + "_" + dest_lang
+        fetch_data_cached = RedisWrapper.cache_it(key, fetch_data)
+        return fetch_data_cached()
+
+
+wikipedia_session = WikipediaSession()

--- a/idunn/places/base.py
+++ b/idunn/places/base.py
@@ -41,7 +41,11 @@ class BasePlace(dict):
         if lang not in self._wiki_resp:
             self._wiki_resp[lang] = None
 
-            if self.wikidata_id is not None:
+            if (
+                self.wikidata_id is not None
+                and wiki_es.enabled()
+                and wiki_es.is_lang_available(lang)
+            ):
                 self._wiki_resp[lang] = wiki_es.get_info(self.wikidata_id, lang)
 
         return self._wiki_resp.get(lang)

--- a/idunn/utils/redis.py
+++ b/idunn/utils/redis.py
@@ -116,6 +116,11 @@ class RedisWrapper:
     def disable(cls):
         cls._connection = DISABLED_STATE
 
+    @classmethod
+    def enable(cls):
+        cls._connection = None
+        cls.init_cache()
+
 
 class RedisWrapperWeather(RedisWrapper):
     _redis = RedisWrapper

--- a/tests/test_api_circuit_breaker.py
+++ b/tests/test_api_circuit_breaker.py
@@ -4,7 +4,8 @@ import responses
 from app import app
 from time import sleep
 from fastapi.testclient import TestClient
-from idunn.blocks.wikipedia import WikipediaSession
+from idunn.datasources.wikipedia import WikipediaSession
+from .test_rate_limiter import disable_redis
 
 
 @pytest.fixture()
@@ -22,7 +23,7 @@ def breaker_test():
     return wiki_breaker
 
 
-def test_circuit_breaker_500(breaker_test):
+def test_circuit_breaker_500(breaker_test, disable_redis):
     """
     Test when the external service returns a
     HTTPError 500.
@@ -55,7 +56,7 @@ def test_circuit_breaker_500(breaker_test):
         assert len(rsps.calls) == 4
 
 
-def test_circuit_breaker_404(breaker_test):
+def test_circuit_breaker_404(breaker_test, disable_redis):
     """
     Same test as 'test_circuit_breaker_500' except
     that the external service returns this time an

--- a/tests/test_wiki_ES.py
+++ b/tests/test_wiki_ES.py
@@ -52,7 +52,7 @@ def test_basket_ball():
                 "senior féminine a accédé jusqu'au championnat professionnel de Ligue 2 (2e "
                 "division nationale), performance remarquée pour un village de 3000 habitants. Le "
                 "club est basé dans la ville de Pleyber-Christ. Il accueille aussi de jeunes "
-                "joueuses de..."
+                "joueuses de…"
             ),
         }
 

--- a/tests/test_wiki_size_limit.py
+++ b/tests/test_wiki_size_limit.py
@@ -48,4 +48,4 @@ def test_wiki_size_limit(wiki_max_size):
 
     # Test that the wiki block description string is not longer than
     # WIKI_DESC_MAX_SIZE (here only 10 chars).
-    assert resp["blocks"][2].get("blocks")[0].get("description") == "El Museo d..."
+    assert resp["blocks"][2].get("blocks")[0].get("description") == "El Museo d…"


### PR DESCRIPTION
Similarly to https://github.com/Qwant/idunn/pull/261, this moves calls to Wikipedia API in its own `source` module and remove the responsibility of handling the cache from the caller.