### PR TITLE
add block `description`

### DIFF
--- a/idunn/api/utils.py
+++ b/idunn/api/utils.py
@@ -17,6 +17,7 @@ from idunn.blocks import (
     WebSiteBlock,
     TransactionalBlock,
     SocialBlock,
+    DescriptionBlock,
 )
 from idunn.utils.settings import _load_yaml_file
 from idunn.datasources.mimirsbrunn import MimirPoiFilter
@@ -134,6 +135,7 @@ BLOCKS_BY_VERBOSITY = {
         RecyclingBlock,
         TransactionalBlock,
         SocialBlock,
+        DescriptionBlock,
     ],
     Verbosity.LIST: [
         OpeningDayEvent,

--- a/idunn/blocks/__init__.py
+++ b/idunn/blocks/__init__.py
@@ -21,6 +21,7 @@ from .environment import AirQuality, Weather
 from .recycling import RecyclingBlock
 from .transactional import TransactionalBlock
 from .social import SocialBlock
+from .description import DescriptionBlock
 
 AnyBlock = Union[
     OpeningHourBlock,
@@ -44,4 +45,5 @@ AnyBlock = Union[
     RecyclingBlock,
     TransactionalBlock,
     SocialBlock,
+    DescriptionBlock,
 ]

--- a/idunn/blocks/description.py
+++ b/idunn/blocks/description.py
@@ -1,0 +1,48 @@
+from enum import Enum
+from typing import Literal, Optional
+
+import idunn
+from idunn import settings
+from idunn.blocks.wikipedia import WikipediaBlock
+from .base import BaseBlock
+
+DESC_MAX_SIZE = int(settings["DESC_MAX_SIZE"])
+
+
+def limit_size(content: str) -> str:
+    if len(content) > DESC_MAX_SIZE:
+        return content[:DESC_MAX_SIZE] + "…"
+
+    return content
+
+
+class DescriptionSources(Enum):
+    OSM = "osm"
+    PAGESJAUNES = "pagesjaunes"
+    WIKIPEDIA = "wikipedia"
+
+
+class DescriptionBlock(BaseBlock):
+    type: Literal["description"] = "description"
+    description: str
+    source: DescriptionSources
+    url: Optional[str]
+
+    @classmethod
+    def from_es(cls, place, lang):
+        if wiki_block := WikipediaBlock.from_es(place, lang):
+            return cls(
+                description=wiki_block.description,
+                source=DescriptionSources.WIKIPEDIA,
+                url=wiki_block.url,
+            )
+
+        if description := place.get_description(lang):
+            if isinstance(place, idunn.places.PjApiPOI):
+                source = DescriptionSources.PAGESJAUNES
+            else:
+                source = DescriptionSources.OSM
+
+            return cls(description=description, source=source)
+
+        return None

--- a/idunn/blocks/description.py
+++ b/idunn/blocks/description.py
@@ -43,6 +43,6 @@ class DescriptionBlock(BaseBlock):
             else:
                 source = DescriptionSources.OSM
 
-            return cls(description=description, source=source)
+            return cls(description=description, source=source, url=place.get_description_url(lang))
 
         return None

--- a/idunn/blocks/description.py
+++ b/idunn/blocks/description.py
@@ -32,7 +32,7 @@ class DescriptionBlock(BaseBlock):
     def from_es(cls, place, lang):
         if wiki_block := WikipediaBlock.from_es(place, lang):
             return cls(
-                description=wiki_block.description,
+                description=limit_size(wiki_block.description),
                 source=DescriptionSources.WIKIPEDIA,
                 url=wiki_block.url,
             )
@@ -43,6 +43,10 @@ class DescriptionBlock(BaseBlock):
             else:
                 source = DescriptionSources.OSM
 
-            return cls(description=description, source=source, url=place.get_description_url(lang))
+            return cls(
+                description=limit_size(description),
+                source=source,
+                url=place.get_description_url(lang),
+            )
 
         return None

--- a/idunn/places/base.py
+++ b/idunn/places/base.py
@@ -275,6 +275,9 @@ class BasePlace(dict):
     def get_description(self, lang):
         return self.properties.get(f"description:{lang}")
 
+    def get_description_url(self, _lang):
+        return None
+
     def get_bbox(self):
         return None
 

--- a/idunn/places/base.py
+++ b/idunn/places/base.py
@@ -272,6 +272,9 @@ class BasePlace(dict):
     def get_quotation_request_url(self):
         return None
 
+    def get_description(self, lang):
+        return self.properties.get(f"description:{lang}")
+
     def get_bbox(self):
         return None
 

--- a/idunn/places/models/pj_info.py
+++ b/idunn/places/models/pj_info.py
@@ -177,7 +177,6 @@ class Response(BaseModel):
     """
     Omitted fields:
       - listing_id: Id of the bloc of the professional
-      - description: The professional ’s description
       - business_website: Business website object
       - videos: Array of videos
       - legal_notices: Array of legal notices
@@ -194,6 +193,7 @@ class Response(BaseModel):
 
     merchant_id: Optional[str] = Field(None, description="Id of the professional")
     merchant_name: Optional[str] = Field(None, description="Name of the professional")
+    description: Optional[str] = Field(None, description="The professional ’s description")
     thumbnail_url: Optional[str] = Field(None, description="URL of the professional ’s thumbnail")
     website_urls: List[WebsiteUrl] = Field([], description="Array of merchant websites URLs")
     business_descriptions: List[BusinessDescription] = Field(

--- a/idunn/places/pj_poi.py
+++ b/idunn/places/pj_poi.py
@@ -512,3 +512,9 @@ class PjApiPOI(BasePlace):
             return None
 
         return self.data.description
+
+    def get_description_url(self, lang):
+        if lang != "fr":
+            return None
+
+        return self.get_source_url()

--- a/idunn/places/pj_poi.py
+++ b/idunn/places/pj_poi.py
@@ -506,3 +506,9 @@ class PjApiPOI(BasePlace):
 
     def get_quotation_request_url(self):
         return self.get_transactional_url([TransactionalLinkType.QUOTATION_REQUEST])
+
+    def get_description(self, lang):
+        if lang != "fr":
+            return None
+
+        return None  # TODO

--- a/idunn/places/pj_poi.py
+++ b/idunn/places/pj_poi.py
@@ -508,7 +508,7 @@ class PjApiPOI(BasePlace):
         return self.get_transactional_url([TransactionalLinkType.QUOTATION_REQUEST])
 
     def get_description(self, lang):
-        if lang != "fr":
+        if lang != "fr" or isinstance(self.data, pj_find.Listing):
             return None
 
-        return None  # TODO
+        return self.data.description

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -50,6 +50,7 @@ PLACE_POI_INDEX: "munin_poi,munin_poi_nosearch"
 PLACE_DEFAULT_INDEX: "munin,munin_poi_nosearch"
 
 WIKI_DESC_MAX_SIZE: 325 # max size allowed to the description of the wiki block
+DESC_MAX_SIZE: 325 # max size allowed in the description block
 
 ## Places list
 LIST_PLACES_MAX_SIZE: 50

--- a/tests/fixtures/pj/api_musee_picasso.json
+++ b/tests/fixtures/pj/api_musee_picasso.json
@@ -50,6 +50,7 @@
             "request_id": "1361606724369457757506724369457"
         }
     },
+    "description": "Le musée Picasso est le musée national français consacré à la vie et à l'œuvre de Pablo Picasso ainsi qu'aux artistes qui lui furent liés. ",
     "inscriptions": [
         {
             "address_city": "Paris",

--- a/tests/test_api_circuit_breaker.py
+++ b/tests/test_api_circuit_breaker.py
@@ -75,7 +75,7 @@ def test_circuit_breaker_404(breaker_test, disable_redis):
             response = client.get(url="http://localhost/v1/pois/osm:way:7777777?lang=es")
 
         assert breaker_test.current_state == "closed"
-        assert len(rsps.calls) == 4
+        assert len(rsps.calls) == 8
 
         resp = response.json()
         assert all(b["type"] != "wikipedia" for b in resp["blocks"])

--- a/tests/test_pj_poi.py
+++ b/tests/test_pj_poi.py
@@ -138,6 +138,13 @@ def test_pj_api_place(enable_pj_source):
         "http://localhost:5000/v1/redirect?url=https%3A%2F%2F%5BTWITTER%5D&hash=c34074b"
     )
 
+    assert blocks[8]["type"] == "description"
+    assert blocks[8]["source"] == "pagesjaunes"
+    assert (
+        blocks[8]["description"]
+        == "Le musée Picasso est le musée national français consacré à la vie et à l'œuvre de Pablo Picasso ainsi qu'aux artistes qui lui furent liés. "
+    )
+
 
 @pytest.mark.parametrize(
     "enable_pj_source",

--- a/tests/test_places.py
+++ b/tests/test_places.py
@@ -380,6 +380,12 @@ def test_full_query_poi():
                 },
             ],
         },
+        {
+            "description": "Collections : Art français et européen de 1848 à 1914",
+            "source": "osm",
+            "type": "description",
+            "url": None,
+        },
     ]
 
 

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -63,9 +63,12 @@ def test_rate_limiter_with_redis(limiter_test_normal, mock_wikipedia_response):
     Test that Idunn stops external requests when
     we are above the max rate
 
-    We mock 5*2 calls to wikipedia while the max number
-    of calls is 3*2, so we test that after 3 calls
-    no more calls are done
+    Each call to Idunn (with cache disabled) outputs two blocks with Wikipedia
+    data, each block requires two request (to translate the title and then to
+    fetch actual content). Which makes 4 calls per POI request to Idunn.
+
+    As `WIKI_API_RL_MAX_CALLS` is set to 12, the blocks won't be displayed
+    after the 3rd request.
     """
     client = TestClient(app)
 

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -32,7 +32,7 @@ def limiter_test_normal(redis, disable_redis):
     """
 
     with override_settings(
-        {"WIKI_API_RL_PERIOD": 5, "WIKI_API_RL_MAX_CALLS": 6, "REDIS_URL": redis}
+        {"WIKI_API_RL_PERIOD": 5, "WIKI_API_RL_MAX_CALLS": 12, "REDIS_URL": redis}
     ):
         # To force settings overriding we need to set to None the limiter
         WikipediaSession.Helpers._rate_limiter = None
@@ -63,7 +63,7 @@ def test_rate_limiter_with_redis(limiter_test_normal, mock_wikipedia_response):
     Test that Idunn stops external requests when
     we are above the max rate
 
-    We mock 5 calls to wikipedia while the max number
+    We mock 5*2 calls to wikipedia while the max number
     of calls is 3*2, so we test that after 3 calls
     no more calls are done
     """
@@ -79,14 +79,14 @@ def test_rate_limiter_with_redis(limiter_test_normal, mock_wikipedia_response):
         resp = response.json()
         assert all(b["type"] != "wikipedia" for b in resp["blocks"][2].get("blocks"))
 
-    assert len(mock_wikipedia_response.calls) == 6
+    assert len(mock_wikipedia_response.calls) == 12
 
 
 def test_rate_limiter_without_redis(disable_redis):
     """
     Test that Idunn doesn't stop external requests when
     no redis has been set: 10 requests to Idunn should
-    generate 10 requests to Wikipedia API
+    generate 20 requests to Wikipedia API
     """
     client = TestClient(app)
 
@@ -97,7 +97,7 @@ def test_rate_limiter_without_redis(disable_redis):
         for _ in range(10):
             client.get(url="http://localhost/v1/pois/osm:relation:7515426?lang=es")
 
-        assert len(rsps.calls) == 10
+        assert len(rsps.calls) == 20
 
 
 def restart_wiki_redis(docker_services):

--- a/tests/test_wiki_ES.py
+++ b/tests/test_wiki_ES.py
@@ -121,7 +121,7 @@ def test_undefined_WIKI_ES(wiki_es_undefined):
         for _ in range(10):
             client.get(url="http://localhost/v1/pois/osm:way:7777777?lang=fr")
 
-        assert len(rsps.calls) == 10
+        assert len(rsps.calls) == 20
 
 
 @freeze_time("2018-06-14 8:30:00", tz_offset=2)
@@ -177,4 +177,4 @@ def test_no_lang_WIKI_ES():
 
         # We make a request in russian language ("ru")
         client.get(url="http://localhost/v1/pois/osm:way:7777777?lang=ru")
-        assert len(rsps.calls) == 1
+        assert len(rsps.calls) == 2


### PR DESCRIPTION
Adds a new `description` block, which contains:

 - the description itself
 - the source of the description (which would be helpful to display labels like "read more on Wikipedia")
 - optionally, the url to the source

The information may come from several sources:

 - Wikipedia if available (which means that the old `wikipedia` block is now deprecated)
 - `description:lang` for OSM. Should we fallback to `decription` without a lang ? It would give much more data but at the cost of loosing some consistency with language, I'm not sure what users actually expect ? (In most case they wouldn't notice as you typically use QMaps in the country you currently live in)
 - `description` for pagesjaunes, although it is only rarely available : we should ask about cases were a description is visible on their website but not in the API :confused: 

For example for [this place](http://localhost:3000/place/pj:56110744@Brasserie_Bofinger#map=16.50/48.8538800/2.3678450) the block is:

```json
{
    "type": "description",
    "description": "DINER SOUS LA COUPOLE - Situé entre Bastille et la place des Vosges, le Bofinger vous reçoit dans un cadre d'exception emprunt d'histoire et de mémoire. Cette élégante brasserie alsacienne du 19e siècle saura vous surprendre avec sa coupole en verre qui illumine la grande salle, ses toiles du célèbre Hansi, ses boiseries, céramiques et miroirs d'époque... POUR LES GOURMETS - Du côté des papilles, le Chef Georges Belondrade met tout en œuvre pour éveiller vos sens. Il travaille poissons et fruits de mer tout en respectant la tradition Bofinger, et vous propose une carte variée qui ravira les fins gourmets. En dessert, vous craquerez volontiers pour le kougelhopf glacé aux griottines sauvages... A NE PAS MANQUER - Une adresse parisienne incontournable qui vous transportera au début des Années Folles. A découvrir sans plus tarder !",
    "source": "pagesjaunes",
    "url": null
}
```