### PR TITLE
add block `delivery`

### DIFF
--- a/idunn/api/utils.py
+++ b/idunn/api/utils.py
@@ -18,6 +18,7 @@ from idunn.blocks import (
     TransactionalBlock,
     SocialBlock,
     DescriptionBlock,
+    DeliveryBlock,
 )
 from idunn.utils.settings import _load_yaml_file
 from idunn.datasources.mimirsbrunn import MimirPoiFilter
@@ -136,6 +137,7 @@ BLOCKS_BY_VERBOSITY = {
         TransactionalBlock,
         SocialBlock,
         DescriptionBlock,
+        DeliveryBlock,
     ],
     Verbosity.LIST: [
         OpeningDayEvent,
@@ -149,6 +151,7 @@ BLOCKS_BY_VERBOSITY = {
         RecyclingBlock,
         TransactionalBlock,
         SocialBlock,
+        DeliveryBlock,
     ],
     Verbosity.SHORT: [OpeningHourBlock, Covid19Block],
 }

--- a/idunn/blocks/__init__.py
+++ b/idunn/blocks/__init__.py
@@ -22,6 +22,7 @@ from .recycling import RecyclingBlock
 from .transactional import TransactionalBlock
 from .social import SocialBlock
 from .description import DescriptionBlock
+from .delivery import DeliveryBlock
 
 AnyBlock = Union[
     OpeningHourBlock,
@@ -46,4 +47,5 @@ AnyBlock = Union[
     TransactionalBlock,
     SocialBlock,
     DescriptionBlock,
+    DeliveryBlock,
 ]

--- a/idunn/blocks/delivery.py
+++ b/idunn/blocks/delivery.py
@@ -1,0 +1,32 @@
+from enum import Enum
+from typing import List, Literal
+
+from .base import BaseBlock
+
+
+class DeliveryType(Enum):
+    CLICK_AND_COLLECT = "click_and_collect"
+    DELIVERY = "delivery"
+    TAKEAWAY = "takeaway"
+
+
+class DeliveryBlock(BaseBlock):
+    type: Literal["delivery"] = "delivery"
+    available: List[DeliveryType]
+
+    @classmethod
+    def from_es(cls, place, lang):
+        available = [
+            delivery_type
+            for delivery_type, is_available in [
+                (DeliveryType.CLICK_AND_COLLECT, place.has_click_and_collect()),
+                (DeliveryType.DELIVERY, place.has_delivery()),
+                (DeliveryType.TAKEAWAY, place.has_takeaway()),
+            ]
+            if is_available
+        ]
+
+        if not available:
+            return None
+
+        return cls(available=available)

--- a/idunn/places/base.py
+++ b/idunn/places/base.py
@@ -285,7 +285,7 @@ class BasePlace(dict):
         return self.properties.get("delivery") == "yes"
 
     def has_takeaway(self):
-        return self.properties.get("takeaway") == "yes"
+        return self.properties.get("takeaway") in ("yes", "only")
 
     def get_bbox(self):
         return None

--- a/idunn/places/base.py
+++ b/idunn/places/base.py
@@ -282,10 +282,10 @@ class BasePlace(dict):
         return False
 
     def has_delivery(self):
-        return False
+        return self.properties.get("delivery") == "yes"
 
     def has_takeaway(self):
-        return False
+        return self.properties.get("takeaway") == "yes"
 
     def get_bbox(self):
         return None

--- a/idunn/places/base.py
+++ b/idunn/places/base.py
@@ -278,6 +278,15 @@ class BasePlace(dict):
     def get_description_url(self, _lang):
         return None
 
+    def has_click_and_collect(self):
+        return False
+
+    def has_delivery(self):
+        return False
+
+    def has_takeaway(self):
+        return False
+
     def get_bbox(self):
         return None
 

--- a/idunn/places/pj_poi.py
+++ b/idunn/places/pj_poi.py
@@ -13,7 +13,7 @@ from ..api.urlsolver import resolve_url
 CLICK_AND_COLLECT = re.compile(r"retrait .*")
 DELIVERY = re.compile(r"commande en ligne|livraison.*")
 TAKEAWAY = re.compile(r".* à emporter")
-WHEELCHAIN_ACCESSIBLE = re.compile("accès (handicapés?|(aux|pour) personnes? à mobilité réduite)")
+WHEELCHAIR_ACCESSIBLE = re.compile("accès (handicapés?|(aux|pour) personnes? à mobilité réduite)")
 
 DOCTORS = (
     "Chiropracteur",
@@ -358,7 +358,7 @@ class PjApiPOI(BasePlace):
     def get_raw_wheelchair(self):
         return (
             any(
-                WHEELCHAIN_ACCESSIBLE.match(label)
+                WHEELCHAIR_ACCESSIBLE.match(label)
                 for desc in self.data.business_descriptions
                 for label in desc.values
             )

--- a/idunn/places/pj_poi.py
+++ b/idunn/places/pj_poi.py
@@ -9,15 +9,11 @@ from .models.pj_info import TransactionalLinkType, UrlType
 from ..api.constants import PoiSource
 from ..api.urlsolver import resolve_url
 
-WHEELCHAIN_ACCESSIBLE = re.compile(
-    "|".join(
-        [
-            "accès handicapés?",
-            "accès aux personnes à mobilité réduite",
-            "accès pour personne à mobilité réduite",
-        ]
-    )
-)
+
+CLICK_AND_COLLECT = re.compile(r"retrait .*")
+DELIVERY = re.compile(r"commande en ligne|livraison.*")
+TAKEAWAY = re.compile(r".* à emporter")
+WHEELCHAIN_ACCESSIBLE = re.compile("accès (handicapés?|(aux|pour) personnes? à mobilité réduite)")
 
 DOCTORS = (
     "Chiropracteur",
@@ -518,3 +514,24 @@ class PjApiPOI(BasePlace):
             return None
 
         return self.get_source_url()
+
+    def has_click_and_collect(self):
+        return any(
+            CLICK_AND_COLLECT.match(label.lower())
+            for desc in self.data.business_descriptions
+            for label in desc.values
+        )
+
+    def has_delivery(self):
+        return any(
+            DELIVERY.match(label.lower())
+            for desc in self.data.business_descriptions
+            for label in desc.values
+        )
+
+    def has_takeaway(self):
+        return any(
+            TAKEAWAY.match(label.lower())
+            for desc in self.data.business_descriptions
+            for label in desc.values
+        )

--- a/tests/fixtures/pj/api_musee_picasso.json
+++ b/tests/fixtures/pj/api_musee_picasso.json
@@ -35,6 +35,16 @@
                 "boutique",
                 "accès aux personnes à mobilité réduite"
             ]
+        },
+        {
+            "label": "Prestations",
+            "values": [
+                "RETRAIT 1H",
+                "ÉCO-COLLECTE",
+                "LIVRAISON 2H CHRONO",
+                "LIVRAISON EN 1 JOUR",
+                "LIVRAISON"
+            ]
         }
     ],
     "categories": [

--- a/tests/test_delivery.py
+++ b/tests/test_delivery.py
@@ -2,9 +2,13 @@ from idunn.blocks.delivery import DeliveryBlock
 from idunn.places import POI
 
 
-def test_website_block():
-    web_block = DeliveryBlock.from_es(
+def test_delivery_block():
+    delivery_block = DeliveryBlock.from_es(
         POI({"properties": {"delivery": "yes", "takeaway": "yes"}}), lang="en"
     )
 
-    assert web_block == DeliveryBlock(available=["delivery", "takeaway"])
+    assert delivery_block == DeliveryBlock(
+        click_and_collect="unknown",
+        delivery="yes",
+        takeaway="yes",
+    )

--- a/tests/test_delivery.py
+++ b/tests/test_delivery.py
@@ -1,0 +1,10 @@
+from idunn.blocks.delivery import DeliveryBlock
+from idunn.places import POI
+
+
+def test_website_block():
+    web_block = DeliveryBlock.from_es(
+        POI({"properties": {"delivery": "yes", "takeaway": "yes"}}), lang="en"
+    )
+
+    assert web_block == DeliveryBlock(available=["delivery", "takeaway"])

--- a/tests/test_pj_poi.py
+++ b/tests/test_pj_poi.py
@@ -140,10 +140,13 @@ def test_pj_api_place(enable_pj_source):
 
     assert blocks[8]["type"] == "description"
     assert blocks[8]["source"] == "pagesjaunes"
-    assert (
-        blocks[8]["description"]
-        == "Le musée Picasso est le musée national français consacré à la vie et à l'œuvre de Pablo Picasso ainsi qu'aux artistes qui lui furent liés. "
+    assert blocks[8]["description"] == (
+        "Le musée Picasso est le musée national français consacré à la vie et à l'œuvre de Pablo "
+        "Picasso ainsi qu'aux artistes qui lui furent liés. "
     )
+
+    assert blocks[9]["type"] == "delivery"
+    assert blocks[9]["available"] == ["click_and_collect", "delivery"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pj_poi.py
+++ b/tests/test_pj_poi.py
@@ -146,7 +146,9 @@ def test_pj_api_place(enable_pj_source):
     )
 
     assert blocks[9]["type"] == "delivery"
-    assert blocks[9]["available"] == ["click_and_collect", "delivery"]
+    assert blocks[9]["click_and_collect"] == "yes"
+    assert blocks[9]["delivery"] == "yes"
+    assert blocks[9]["takeaway"] == "unknown"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Add a new `delivery` block which list 'delivery' options.

For example with [this poi](http://localhost:3000/place/pj:08692611@DARTY_Montparnasse) it outputs following block:

```json
{
    "type": "delivery",
    "click_and_collect": "yes",
    "takeaway": "unknown",
    "delivery": "yes"
}
```

EDIT: I finally added support for basic OSM tags for [`takeaway=yes`](https://taginfo.openstreetmap.org/keys/takeaway#values) and [`delivery=yes`](https://taginfo.openstreetmap.org/keys/?key=delivery#values), since it's basically free and stills ads information for respectively about 252k and 37k POIs.