### PR TITLE
block/description: support OSM's `description` when country lang is known

### DIFF
--- a/idunn/places/base.py
+++ b/idunn/places/base.py
@@ -22,6 +22,41 @@ ZONE_TYPE_ORDER_KEY = {
     "country": 7,
 }
 
+# List of official languages for given country codes.
+COUNTRY_LANGUAGES = {
+    # European coutries (source: https://en.wikipedia.org/wiki/Member_state_of_the_European_Union)
+    "at": ["de"],
+    "be": ["nl", "fr", "de"],
+    "bg": ["bg"],
+    "hr": ["hr"],
+    "cy": ["el", "tr"],
+    "cz": ["cs"],
+    "dk": ["da"],
+    "ee": ["et"],
+    "fi": ["fi", "sv"],
+    "fr": ["fr"],
+    "de": ["de"],
+    "gr": ["el"],
+    "hu": ["hu"],
+    "ie": ["en", "ga"],
+    "it": ["it"],
+    "lv": ["lv"],
+    "lt": ["lt"],
+    "lu": ["fr", "de", "lu"],
+    "mt": ["mt", "en"],
+    "nl": ["nl"],
+    "pl": ["pl"],
+    "pt": ["pt"],
+    "ro": ["ro"],
+    "sk": ["sk"],
+    "si": ["sl"],
+    "es": ["es", "gl", "ca", "oc", "eu"],
+    "se": ["sv"],
+    # Other countries
+    "gb": ["en"],
+    "us": ["en"],
+}
+
 
 class BasePlace(dict):
     PLACE_TYPE = ""
@@ -273,7 +308,17 @@ class BasePlace(dict):
         return None
 
     def get_description(self, lang):
-        return self.properties.get(f"description:{lang}")
+        if f"description:{lang}" in self.properties:
+            return self.properties.get(f"description:{lang}")
+
+        country_code = self.get_country_code()
+
+        # Check that there is little to no ambiguity on local language and that
+        # it matches `lang`.
+        if not country_code or COUNTRY_LANGUAGES.get(country_code.lower()) != [lang.lower()]:
+            return None
+
+        return self.properties.get("description")
 
     def get_description_url(self, _lang):
         return None

--- a/tests/test_description.py
+++ b/tests/test_description.py
@@ -1,0 +1,33 @@
+from idunn.blocks.description import DescriptionBlock
+from idunn.places import POI
+from .utils import read_fixture
+
+
+def orsay(lang=None):
+    place = {"properties": {}}
+
+    full = read_fixture("fixtures/orsay_museum.json")
+    place["administrative_regions"] = full["administrative_regions"]
+
+    key = f"description:{lang}" if lang else "description"
+    place["properties"][key] = "Le musée d’Orsay est un musée national inauguré en 1986."
+
+    return POI(place)
+
+
+def test_description_block_with_lang():
+    assert DescriptionBlock.from_es(orsay(lang="fr"), lang="en") is None
+    assert DescriptionBlock.from_es(orsay(lang="fr"), lang="fr") == DescriptionBlock(
+        type="description",
+        description="Le musée d’Orsay est un musée national inauguré en 1986.",
+        source="osm",
+    )
+
+
+def test_description_block_without_lang():
+    assert DescriptionBlock.from_es(orsay(), lang="en") is None
+    assert DescriptionBlock.from_es(orsay(), lang="fr") == DescriptionBlock(
+        type="description",
+        description="Le musée d’Orsay est un musée national inauguré en 1986.",
+        source="osm",
+    )


### PR DESCRIPTION
OSM's `description` block is [quite abundant](https://taginfo.openstreetmap.org/keys/description) but not integrated in https://github.com/Qwant/idunn/pull/263.

This PR supports it for a bunch of countries with a unique official language if the user language matches the local languages.

I manually referenced European Union countries together with US and UK which should cover most of our users. I didn't want to only stick to France as adding this kind of information is quite light to add in Idunn, but sadly I didn't manage to put hands on a good exhaustive database.