### PR TITLE
tests: fix tiny inconsistencies with variable names in block tests

### DIFF
--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -5,15 +5,15 @@ from idunn.places import POI
 
 
 def test_accessibility_block():
-    web_block = AccessibilityBlock.from_es(
+    accessibility_block = AccessibilityBlock.from_es(
         POI({"properties": {"wheelchair": "limited", "toilets:wheelchair": "no"}}), lang="en"
     )
 
-    assert web_block == AccessibilityBlock(wheelchair="partial", toilets_wheelchair="no")
+    assert accessibility_block == AccessibilityBlock(wheelchair="partial", toilets_wheelchair="no")
 
 
 def test_accessibility_unknown():
-    web_block = AccessibilityBlock.from_es(
+    accessibility_block = AccessibilityBlock.from_es(
         POI(
             {
                 "properties": {
@@ -23,7 +23,7 @@ def test_accessibility_unknown():
         ),
         lang="en",
     )
-    assert web_block is None
+    assert accessibility_block is None
 
 
 def test_undefined_wheelchairs():

--- a/tests/test_brewery.py
+++ b/tests/test_brewery.py
@@ -1,11 +1,11 @@
 from idunn.blocks.services_and_information import BreweryBlock, Beer
 
 
-def test_internet_access_block():
-    web_block = BreweryBlock.from_es(
+def test_brewery_block():
+    brewery_block = BreweryBlock.from_es(
         {"properties": {"brewery": "Tripel Karmeliet;Delirium;Chouffe"}}, lang="en"
     )
 
-    assert web_block == BreweryBlock(
+    assert brewery_block == BreweryBlock(
         beers=[Beer(name="Tripel Karmeliet"), Beer(name="Delirium"), Beer(name="Chouffe")]
     )

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -3,11 +3,11 @@ from idunn.places import POI
 
 
 def test_contact_block():
-    web_block = ContactBlock.from_es(
+    contact_block = ContactBlock.from_es(
         POI({"properties": {"contact:email": "info@pershinghall.com"}}), lang="en"
     )
 
-    assert web_block == ContactBlock(
+    assert contact_block == ContactBlock(
         url="mailto:info@pershinghall.com",
         email="info@pershinghall.com",
     )

--- a/tests/test_cuisine.py
+++ b/tests/test_cuisine.py
@@ -2,9 +2,9 @@ from idunn.blocks.services_and_information import CuisineBlock, Cuisine
 
 
 def test_cuisine_block():
-    web_block = CuisineBlock.from_es({"properties": {"cuisine": "Italian;French"}}, lang="en")
+    cuisine_block = CuisineBlock.from_es({"properties": {"cuisine": "Italian;French"}}, lang="en")
 
-    assert web_block == CuisineBlock(
+    assert cuisine_block == CuisineBlock(
         cuisines=[Cuisine(name="Italian"), Cuisine(name="French")],
         vegetarian=CuisineBlock.STATUS_UNKNOWN,
         vegan=CuisineBlock.STATUS_UNKNOWN,

--- a/tests/test_grades.py
+++ b/tests/test_grades.py
@@ -3,7 +3,7 @@ from idunn.places import PjPOI
 
 
 def test_grades_block():
-    web_block = GradesBlock.from_es(
+    grades_block = GradesBlock.from_es(
         PjPOI(
             {
                 "grades": {
@@ -15,4 +15,4 @@ def test_grades_block():
         lang="en",
     )
 
-    assert web_block == GradesBlock(total_grades_count=8, global_grade=4.0, url=None)
+    assert grades_block == GradesBlock(total_grades_count=8, global_grade=4.0, url=None)

--- a/tests/test_internet_access.py
+++ b/tests/test_internet_access.py
@@ -2,10 +2,12 @@ from idunn.blocks.services_and_information import InternetAccessBlock
 
 
 def test_internet_access_block():
-    web_block = InternetAccessBlock.from_es({"properties": {"wifi": "no"}}, lang="en")
-    assert web_block is None
+    internet_access_block = InternetAccessBlock.from_es({"properties": {"wifi": "no"}}, lang="en")
+    assert internet_access_block is None
 
 
 def test_internet_access_block_ok():
-    web_block = InternetAccessBlock.from_es({"properties": {"internet_access": "wlan"}}, lang="en")
-    assert web_block == InternetAccessBlock(wifi=True)
+    internet_access_block = InternetAccessBlock.from_es(
+        {"properties": {"internet_access": "wlan"}}, lang="en"
+    )
+    assert internet_access_block == InternetAccessBlock(wifi=True)


### PR DESCRIPTION
I'm trying to get into the habit of not polluting my pull requests with some unrelated stuff, but sometime it's hard to ignore insignificant issues when you see one :no_mouth: 