### PR TITLE
Fix: ignore city name 'null' in PJ API response

### DIFF
--- a/idunn/places/pj_poi.py
+++ b/idunn/places/pj_poi.py
@@ -383,9 +383,9 @@ class PjApiPOI(BasePlace):
         if not inscription:
             city, postcode, street_and_number = [""] * 3
         else:
-            city = inscription.address_city
-            postcode = inscription.address_zipcode
-            street_and_number = inscription.address_street
+            city = inscription.address_city or ""
+            postcode = inscription.address_zipcode or ""
+            street_and_number = inscription.address_street or ""
 
         return {
             "id": None,
@@ -405,13 +405,27 @@ class PjApiPOI(BasePlace):
         }
 
     def build_admins(self, lang=None) -> list:
+        """
+        >>> poi = PjApiPOI(pj_info.Response(**{
+        ...    "inscriptions": [
+        ...        {
+        ...         "address_city": None,
+        ...         "address_district": "03",
+        ...         "address_street": "5 r Thorigny",
+        ...         "address_zipcode": "75003",
+        ...         "latitude": 48.859702,
+        ...         "longitude": 2.362634,
+        ...     }
+        ... ]}))
+        >>> assert poi.build_admins() == [], f"Got {poi.build_admins()}"
+        """
         inscription = self.get_inscription_with_address()
 
-        if not inscription:
+        if not inscription or not inscription.address_city:
             return []
 
         city = inscription.address_city
-        postcode = inscription.address_zipcode
+        postcode = inscription.address_zipcode or ""
 
         if postcode:
             label = f"{city} ({postcode})"


### PR DESCRIPTION
## Description
This PR fixes a server error caused by a non-supported edge case in PJ data.

## Details

In rare cases, data returned by PJ API may contain `"address_city": null` in POI "inscriptions".   

This is consistent with the `Optional[str]` used by the data model, but breaks an implicit assumption on "admin" objects used by the result filter. The `"name"` value is assumed to be a string and is converted to lowercase:

https://github.com/Qwant/idunn/blob/f9d33b2f90a4eabfe4752bdefe1769bb2fbdef03/idunn/utils/result_filter.py#L359

https://github.com/Qwant/idunn/blob/f9d33b2f90a4eabfe4752bdefe1769bb2fbdef03/idunn/utils/result_filter.py#L199

This is a quick fix. A cleaner solution could be to use a pydantic model to validate the "admin" object upstream, before it's used by the `ResultFilter`
