### PR TITLE
pj_poi: add `contribute_url` to `meta` fields

### DIFF
--- a/idunn/places/pj_poi.py
+++ b/idunn/places/pj_poi.py
@@ -232,6 +232,14 @@ class PjPOI(BasePlace):
             return None
         return f"https://www.pagesjaunes.fr/pros/{business_id}"
 
+    def get_contribute_url(self):
+        source_url = self.get_source_url()
+
+        if not source_url:
+            return None
+
+        return f"{source_url}#CFMonEntreprise"
+
     def get_raw_grades(self):
         return self.get("grades")
 
@@ -438,6 +446,14 @@ class PjApiPOI(BasePlace):
 
     def get_source_url(self):
         return f"https://www.pagesjaunes.fr/pros/{self.data.merchant_id}"
+
+    def get_contribute_url(self):
+        source_url = self.get_source_url()
+
+        if not source_url:
+            return None
+
+        return f"{source_url}#CFMonEntreprise"
 
     def get_raw_grades(self):
         grade_count = sum(

--- a/idunn/places/pj_poi.py
+++ b/idunn/places/pj_poi.py
@@ -238,7 +238,7 @@ class PjPOI(BasePlace):
         if not source_url:
             return None
 
-        return f"{source_url}#CFMonEntreprise"
+        return f"{source_url}#zone-informations-pratiques"
 
     def get_raw_grades(self):
         return self.get("grades")
@@ -453,7 +453,7 @@ class PjApiPOI(BasePlace):
         if not source_url:
             return None
 
-        return f"{source_url}#CFMonEntreprise"
+        return f"{source_url}#zone-informations-pratiques"
 
     def get_raw_grades(self):
         grade_count = sum(

--- a/tests/test_pj_poi.py
+++ b/tests/test_pj_poi.py
@@ -78,7 +78,13 @@ def test_pj_place(enable_pj_source):
     assert resp["class_name"] == "museum"
     assert resp["subclass_name"] == "museum"
     assert resp["type"] == "poi"
-    assert resp["meta"]["source"] == "pages_jaunes"
+    assert resp["meta"] == {
+        "source": "pages_jaunes",
+        "source_url": "https://www.pagesjaunes.fr/pros/05360257",
+        "contribute_url": "https://www.pagesjaunes.fr/pros/05360257#CFMonEntreprise",
+        "maps_directions_url": "https://www.qwant.com/maps/routes/?destination=pj%3A05360257",
+        "maps_place_url": "https://www.qwant.com/maps/place/pj:05360257",
+    }
     assert resp["geometry"]["center"] == [2.362634, 48.859702]
 
     assert resp["address"]["admins"]

--- a/tests/test_pj_poi.py
+++ b/tests/test_pj_poi.py
@@ -81,7 +81,7 @@ def test_pj_place(enable_pj_source):
     assert resp["meta"] == {
         "source": "pages_jaunes",
         "source_url": "https://www.pagesjaunes.fr/pros/05360257",
-        "contribute_url": "https://www.pagesjaunes.fr/pros/05360257#CFMonEntreprise",
+        "contribute_url": "https://www.pagesjaunes.fr/pros/05360257#zone-informations-pratiques",
         "maps_directions_url": "https://www.qwant.com/maps/routes/?destination=pj%3A05360257",
         "maps_place_url": "https://www.qwant.com/maps/place/pj:05360257",
     }


### PR DESCRIPTION
Construct `poi.meta.contribute_url` for pagesjaune's POIs. In practice this will give anchor links like https://www.pagesjaunes.fr/pros/05360257#CFMonEntreprise. However as you can see the block is hidden by the fixed page header, I see two solutions to this:

 - actually provide a link to the previous element, to give an offset (I'm not a fan of this option, this is very dirty and lacks robustness)
 - keep it as it is, even if not ideal, and just report the issue to pagesjaune