### PR TITLE
Update http response for `search` endpoint

### DIFF
--- a/idunn/api/geocoder.py
+++ b/idunn/api/geocoder.py
@@ -91,6 +91,7 @@ async def get_autocomplete(
                 )
             )
         autocomplete_response["intentions"] = intentions
+    autocomplete_response["geocoding"]["query"] = query.q
     return IdunnAutocomplete(**autocomplete_response)
 
 

--- a/idunn/api/search.py
+++ b/idunn/api/search.py
@@ -29,8 +29,8 @@ async def search(
         return Response(status_code=200, content=build_empty_query_content_response())
     response = await get_autocomplete(query, extra)
 
-    # When no result was found for an acceptable query
-    if not response.features and query.q != "":
+    # When no result was found for an acceptable query (not empty)
+    if not response.features:
         return Response(status_code=204)
 
     # When an intention is detected, it takes over on geocoding features

--- a/idunn/api/search.py
+++ b/idunn/api/search.py
@@ -6,7 +6,7 @@ from idunn import settings
 from idunn.api.geocoder import get_autocomplete
 from idunn.utils.result_filter import ResultFilter
 from idunn.instant_answer import normalize
-from ..geocoder.models import ExtraParams, QueryParams
+from ..geocoder.models import ExtraParams, QueryParams, IdunnAutocomplete
 
 logger = logging.getLogger(__name__)
 result_filter = ResultFilter(match_word_prefix=True, min_matching_words=3)
@@ -15,7 +15,7 @@ nlu_allowed_languages = settings["NLU_ALLOWED_LANGUAGES"].split(",")
 
 
 async def search(
-    query: QueryParams = Depends(QueryParams), extra: ExtraParams = Body(ExtraParams())
+        query: QueryParams = Depends(QueryParams), extra: ExtraParams = Body(ExtraParams())
 ):
     """
     Perform a query which is intended to display a relevant result directly (as
@@ -25,10 +25,13 @@ async def search(
     """
     # Fetch autocomplete results which will be filtered
     query.q = normalize(query.q)
+    if query.q == "":
+        return Response(status_code=200,
+                        content=build_empty_query_content_response())
     response = await get_autocomplete(query, extra)
 
     # When no result was found for an acceptable query
-    if len(response.dict()["features"]) == 0 and query.q != "":
+    if not response.features and query.q != "":
         return Response(status_code=204)
 
     # When an intention is detected, it takes over on geocoding features
@@ -46,3 +49,7 @@ async def search(
         response.features = []
 
     return response
+
+
+def build_empty_query_content_response():
+    return '{"type":"FeatureCollection","geocoding":{"version":"0.1.0","query":""},"intentions":[],"features":[]}'

--- a/idunn/api/search.py
+++ b/idunn/api/search.py
@@ -6,7 +6,7 @@ from idunn import settings
 from idunn.api.geocoder import get_autocomplete
 from idunn.utils.result_filter import ResultFilter
 from idunn.instant_answer import normalize
-from ..geocoder.models import ExtraParams, QueryParams, IdunnAutocomplete
+from ..geocoder.models import ExtraParams, QueryParams
 
 logger = logging.getLogger(__name__)
 result_filter = ResultFilter(match_word_prefix=True, min_matching_words=3)

--- a/idunn/api/search.py
+++ b/idunn/api/search.py
@@ -51,5 +51,7 @@ async def search(
 
 
 def build_empty_query_content_response():
-    return '{"type":"FeatureCollection","geocoding":{"version":"0.1.0","query":""}' \
-           ',"intentions":[],"features":[]}'
+    return (
+        '{"type":"FeatureCollection","geocoding":{"version":"0.1.0","query":""}'
+        ',"intentions":[],"features":[]}'
+    )

--- a/idunn/api/search.py
+++ b/idunn/api/search.py
@@ -25,9 +25,11 @@ async def search(
     """
     # Fetch autocomplete results which will be filtered
     query.q = normalize(query.q)
-    if query.q == "":
-        return Response(status_code=204)
     response = await get_autocomplete(query, extra)
+
+    # When no result was found for an acceptable query
+    if len(response.dict()["features"]) == 0 and query.q != "":
+        return Response(status_code=204)
 
     # When an intention is detected, it takes over on geocoding features
     if response.intentions:

--- a/idunn/api/search.py
+++ b/idunn/api/search.py
@@ -6,7 +6,7 @@ from idunn import settings
 from idunn.api.geocoder import get_autocomplete
 from idunn.utils.result_filter import ResultFilter
 from idunn.instant_answer import normalize
-from ..geocoder.models import ExtraParams, QueryParams, IdunnAutocomplete
+from ..geocoder.models import ExtraParams, QueryParams
 
 logger = logging.getLogger(__name__)
 result_filter = ResultFilter(match_word_prefix=True, min_matching_words=3)
@@ -15,7 +15,7 @@ nlu_allowed_languages = settings["NLU_ALLOWED_LANGUAGES"].split(",")
 
 
 async def search(
-        query: QueryParams = Depends(QueryParams), extra: ExtraParams = Body(ExtraParams())
+    query: QueryParams = Depends(QueryParams), extra: ExtraParams = Body(ExtraParams())
 ):
     """
     Perform a query which is intended to display a relevant result directly (as
@@ -26,8 +26,7 @@ async def search(
     # Fetch autocomplete results which will be filtered
     query.q = normalize(query.q)
     if query.q == "":
-        return Response(status_code=200,
-                        content=build_empty_query_content_response())
+        return Response(status_code=200, content=build_empty_query_content_response())
     response = await get_autocomplete(query, extra)
 
     # When no result was found for an acceptable query
@@ -52,4 +51,5 @@ async def search(
 
 
 def build_empty_query_content_response():
-    return '{"type":"FeatureCollection","geocoding":{"version":"0.1.0","query":""},"intentions":[],"features":[]}'
+    return '{"type":"FeatureCollection","geocoding":{"version":"0.1.0","query":""}' \
+           ',"intentions":[],"features":[]}'

--- a/idunn/api/search.py
+++ b/idunn/api/search.py
@@ -1,5 +1,6 @@
 import logging
 from fastapi import Body, Depends
+from starlette.responses import Response
 
 from idunn import settings
 from idunn.api.geocoder import get_autocomplete
@@ -15,7 +16,7 @@ nlu_allowed_languages = settings["NLU_ALLOWED_LANGUAGES"].split(",")
 
 async def search(
     query: QueryParams = Depends(QueryParams), extra: ExtraParams = Body(ExtraParams())
-) -> IdunnAutocomplete:
+):
     """
     Perform a query which is intended to display a relevant result directly (as
     opposed to `autocomplete` which gives a list of plausible results).
@@ -24,6 +25,8 @@ async def search(
     """
     # Fetch autocomplete results which will be filtered
     query.q = normalize(query.q)
+    if query.q == "":
+        return Response(status_code=204)
     response = await get_autocomplete(query, extra)
 
     # When an intention is detected, it takes over on geocoding features

--- a/idunn/api/urls.py
+++ b/idunn/api/urls.py
@@ -87,6 +87,9 @@ def get_api_urls(settings):
             search,
             methods=["GET", "POST"],
             response_model=IdunnAutocomplete,
+            responses={
+                204: {"description": "Empty search provided"},
+            },
             response_model_exclude_unset=True,
         ),
         # Solve URLs

--- a/tests/fixtures/autocomplete/__init__.py
+++ b/tests/fixtures/autocomplete/__init__.py
@@ -75,6 +75,10 @@ def mock_NLU_with_city(httpx_mock):
 @pytest.fixture
 def mock_autocomplete_get(httpx_mock):
     with override_settings({"BRAGI_BASE_URL": BASE_URL}):
+        httpx_mock.get(re.compile(f"^{BASE_URL}/autocomplete.*q=bloublou")).respond(
+            json=read_fixture("fixtures/autocomplete/empty.json")
+        )
+
         httpx_mock.get(re.compile(f"^{BASE_URL}/autocomplete.*q=(paris|parigi).*")).respond(
             json=read_fixture("fixtures/autocomplete/paris.json")
         )

--- a/tests/fixtures/autocomplete/empty.json
+++ b/tests/fixtures/autocomplete/empty.json
@@ -1,0 +1,8 @@
+{
+  "type": "FeatureCollection",
+  "geocoding": {
+    "version": "0.1.0",
+    "query": ""
+  },
+  "features": []
+}

--- a/tests/fixtures/autocomplete/paris.json
+++ b/tests/fixtures/autocomplete/paris.json
@@ -2,7 +2,7 @@
   "type": "FeatureCollection",
   "geocoding": {
     "version": "0.1.0",
-    "query": ""
+    "query": "paris"
   },
   "features": [
     {

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -15,7 +15,7 @@ def test_empty_search(mock_autocomplete_get, mock_NLU_with_city):
     assert response.status_code == 204
 
 
-def test_serch_qwant_maps(mock_autocomplete_get, mock_NLU_with_city):
+def test_search_qwant_maps(mock_autocomplete_get, mock_NLU_with_city):
     client = TestClient(app)
     response = client.get("/v1/search", params={"q": "qwant maps", "lang": "fr", "nlu": True})
     assert response.status_code == 204

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -12,12 +12,22 @@ from .fixtures.autocomplete import (
 def test_empty_search(mock_autocomplete_get, mock_NLU_with_city):
     client = TestClient(app)
     response = client.get("/v1/search", params={"q": "", "lang": "fr", "nlu": True})
-    assert response.status_code == 204
+    assert response.status_code == 200
+    response_json = response.json()
+    assert response_json["geocoding"]["query"] == ""
 
 
 def test_search_qwant_maps(mock_autocomplete_get, mock_NLU_with_city):
     client = TestClient(app)
     response = client.get("/v1/search", params={"q": "qwant maps", "lang": "fr", "nlu": True})
+    assert response.status_code == 200
+    response_json = response.json()
+    assert response_json["geocoding"]["query"] == ""
+
+
+def test_search_bloublou_without_answer(mock_autocomplete_get, mock_NLU_with_city):
+    client = TestClient(app)
+    response = client.get("/v1/search", params={"q": "bloublou", "lang": "fr", "nlu": True})
     assert response.status_code == 204
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -9,12 +9,25 @@ from .fixtures.autocomplete import (
 )
 
 
+def test_empty_search(mock_autocomplete_get, mock_NLU_with_city):
+    client = TestClient(app)
+    response = client.get("/v1/search", params={"q": "", "lang": "fr", "nlu": True})
+    assert response.status_code == 204
+
+
+def test_serch_qwant_maps(mock_autocomplete_get, mock_NLU_with_city):
+    client = TestClient(app)
+    response = client.get("/v1/search", params={"q": "qwant maps", "lang": "fr", "nlu": True})
+    assert response.status_code == 204
+
+
 def test_search_paris(mock_autocomplete_get, mock_NLU_with_city):
     client = TestClient(app)
     response = client.get("/v1/search", params={"q": "paris", "lang": "fr", "nlu": True})
     assert response.status_code == 200
     response_json = response.json()
     place = response_json["features"][0]["properties"]["geocoding"]
+    assert response_json["geocoding"]["query"] == "paris"
     assert place["name"] == "Paris"
 
 
@@ -24,5 +37,6 @@ def test_search_intention_full_text(mock_NLU_with_brand_and_city, mock_autocompl
     assert response.status_code == 200
     response_json = response.json()
     intention = response_json["intentions"][0]["filter"]
+    assert response_json["geocoding"]["query"] == "auchan à paris"
     assert intention["q"] == "auchan"
     assert intention["bbox"] is not None


### PR DESCRIPTION
Fix https://jira.qwant.ninja/browse/QMAPS-2199

Return 204 http response when the query is acceptable but no results are return from elasticsearch
Return 200 http response when the query is acceptable and results are return from elasticsearch OR the query is empty and no result from ES. 
We also update the query field with the actual query made to ES 