### PR TITLE
explicitly set project name for tests's docker compose

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,11 @@ from .utils import init_wiki_es, override_settings
 
 
 @pytest.fixture(scope="session")
+def docker_services_project_name(pytestconfig):
+    return "idunn_test"
+
+
+@pytest.fixture(scope="session")
 def mimir_es(docker_services):
     """Ensure that ES is up and responsive."""
     docker_services.start("mimir_es")


### PR DESCRIPTION
I've run into an issue with my current setup (on both laptops, so that's most likely an issue with docker-compose 2.2, and not specific to my new installation), tests are able to spawn docker containers but won't be able to find them.

I've filed an issue on https://github.com/lovelysystems/lovely-pytest-docker/issues/27, but in the mean time we can explicitly set the project name in `conftest.py`. This will also spawn more human readable docker images during tests (`idunn_test-mimir_es-1` instead of `$HOME/path/to/idunn-mimir_es-1`.