### PR TITLE
wrap tripadvisor's ratings image in thumbr

### DIFF
--- a/idunn/blocks/images.py
+++ b/idunn/blocks/images.py
@@ -1,69 +1,16 @@
 import re
 import logging
-import hashlib
-import posixpath
-import urllib.parse
-from urllib.parse import urlsplit, unquote, quote
+from urllib.parse import quote
 from pydantic import BaseModel, validator
 from typing import List, Literal
 
 from idunn import settings
 from idunn.api.constants import PoiSource
+from idunn.utils.thumbr import thumbr
 from .base import BaseBlock
 
 
 logger = logging.getLogger(__name__)
-
-
-class ThumbrHelper:
-    def __init__(self):
-        self._thumbr_urls = settings.get("THUMBR_URLS").split(",")
-        self._thumbr_enabled = settings.get("THUMBR_ENABLED")
-        self._salt = settings.get("THUMBR_SALT") or ""
-        if self._thumbr_enabled and not self._salt:
-            logger.warning("Thumbr salt is empty")
-
-    def get_salt(self):
-        return self._salt
-
-    def is_enabled(self):
-        return bool(self._thumbr_enabled)
-
-    def get_thumbr_url(self, img_hash):
-        n = int(img_hash[0], 16) % (len(self._thumbr_urls))
-        return self._thumbr_urls[n]
-
-    def get_url_remote_thumbnail(
-        self,
-        source,
-        width=0,
-        height=0,
-        bestFit=True,
-        progressive=False,
-        animated=False,
-        displayErrorImage=False,
-    ):
-        size = f"{width}x{height}"
-        token = f"{source}{size}{self.get_salt()}"
-        img_hash = hashlib.sha256(bytes(token, encoding="utf8")).hexdigest()
-        base_url = self.get_thumbr_url(img_hash)
-
-        hashURLpart = f"{img_hash[0]}/{img_hash[1]}/{img_hash[2:]}"
-        filename = posixpath.basename(unquote(urlsplit(source).path))
-
-        if not bool(re.match(r"^.*\.(jpg|jpeg|png|gif)$", filename, re.IGNORECASE)):
-            filename += ".jpg"
-
-        params = urllib.parse.urlencode(
-            {
-                "u": source,
-                "q": 1 if displayErrorImage else 0,
-                "b": 1 if bestFit else 0,
-                "p": 1 if progressive else 0,
-                "a": 1 if animated else 0,
-            }
-        )
-        return base_url + "/" + size + "/" + hashURLpart + "/" + filename + "?" + params
 
 
 class Image(BaseModel):
@@ -82,17 +29,10 @@ class Image(BaseModel):
 class ImagesBlock(BaseBlock):
     type: Literal["images"] = "images"
     images: List[Image]
-    _thumb_helper = None
 
     @classmethod
     def is_enabled(cls):
         return settings["BLOCK_IMAGES_ENABLED"]
-
-    @classmethod
-    def get_thumbr_helper(cls):
-        if cls._thumb_helper is None:
-            cls._thumb_helper = ThumbrHelper()
-        return cls._thumb_helper
 
     @staticmethod
     def get_source_url(raw_url):
@@ -110,7 +50,6 @@ class ImagesBlock(BaseBlock):
 
     @classmethod
     def build_image(cls, raw_url, **kwargs):
-        thumbr = cls.get_thumbr_helper()
         if thumbr.is_enabled():
             thumb_url = thumbr.get_url_remote_thumbnail(raw_url)
         else:

--- a/idunn/places/base.py
+++ b/idunn/places/base.py
@@ -283,9 +283,11 @@ class BasePlace(dict):
 
     def get_bubble_star_url(self):
         if self.properties.get("ta:average_rating") is not None:
+            rating = float(self.properties.get("ta:average_rating"))
+
             base_url = (
                 f"https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/"
-                f"{self.properties.get('ta:average_rating')}-MCID-66562.svg"
+                f"{rating:.1f}-MCID-66562.svg"
             )
 
             if thumbr.is_enabled():

--- a/idunn/places/base.py
+++ b/idunn/places/base.py
@@ -5,6 +5,7 @@ from pytz import timezone, UTC
 from typing import Optional, Union
 from idunn.datasources.wiki_es import wiki_es
 from idunn.utils import maps_urls, tz
+from idunn.utils.thumbr import thumbr
 from .place import Place, PlaceMeta
 from ..utils.verbosity import build_blocks, Verbosity
 
@@ -282,10 +283,16 @@ class BasePlace(dict):
 
     def get_bubble_star_url(self):
         if self.properties.get("ta:average_rating") is not None:
-            return (
+            base_url = (
                 f"https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/"
                 f"{self.properties.get('ta:average_rating')}-MCID-66562.svg"
             )
+
+            if thumbr.is_enabled():
+                return thumbr.get_url_remote_thumbnail(base_url)
+
+            return base_url
+
         return None
 
     def load_place(self, lang, verbosity: Verbosity = Verbosity.default()) -> Place:

--- a/idunn/places/base.py
+++ b/idunn/places/base.py
@@ -282,12 +282,16 @@ class BasePlace(dict):
         )
 
     def get_bubble_star_url(self):
-        if self.properties.get("ta:average_rating") is not None:
-            rating = float(self.properties.get("ta:average_rating"))
+        rating = self.properties.get("ta:average_rating")
+
+        if rating is not None:
+            # Tripadvisor bubble star url need a rating with exactly one decimal point
+            # (e.g 4.0 or 4.5)
+            rating = f"{float(rating):.1f}"
 
             base_url = (
-                f"https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/"
-                f"{rating:.1f}-MCID-66562.svg"
+                r"https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/"
+                f"{rating}-MCID-66562.svg"
             )
 
             if thumbr.is_enabled():

--- a/idunn/utils/thumbr.py
+++ b/idunn/utils/thumbr.py
@@ -1,0 +1,64 @@
+import re
+import logging
+import hashlib
+import posixpath
+import urllib.parse
+from urllib.parse import urlsplit, unquote
+
+from idunn import settings
+
+logger = logging.getLogger(__name__)
+
+
+class ThumbrHelper:
+    def __init__(self):
+        self._thumbr_urls = settings.get("THUMBR_URLS").split(",")
+        self._thumbr_enabled = settings.get("THUMBR_ENABLED")
+        self._salt = settings.get("THUMBR_SALT") or ""
+        if self._thumbr_enabled and not self._salt:
+            logger.warning("Thumbr salt is empty")
+
+    def get_salt(self):
+        return self._salt
+
+    def is_enabled(self):
+        return bool(self._thumbr_enabled)
+
+    def get_thumbr_url(self, img_hash):
+        n = int(img_hash[0], 16) % (len(self._thumbr_urls))
+        return self._thumbr_urls[n]
+
+    def get_url_remote_thumbnail(
+        self,
+        source,
+        width=0,
+        height=0,
+        bestFit=True,
+        progressive=False,
+        animated=False,
+        displayErrorImage=False,
+    ):
+        size = f"{width}x{height}"
+        token = f"{source}{size}{self.get_salt()}"
+        img_hash = hashlib.sha256(bytes(token, encoding="utf8")).hexdigest()
+        base_url = self.get_thumbr_url(img_hash)
+
+        hashURLpart = f"{img_hash[0]}/{img_hash[1]}/{img_hash[2:]}"
+        filename = posixpath.basename(unquote(urlsplit(source).path))
+
+        if not bool(re.match(r"^.*\.(jpg|jpeg|png|gif|svg)$", filename, re.IGNORECASE)):
+            filename += ".jpg"
+
+        params = urllib.parse.urlencode(
+            {
+                "u": source,
+                "q": 1 if displayErrorImage else 0,
+                "b": 1 if bestFit else 0,
+                "p": 1 if progressive else 0,
+                "a": 1 if animated else 0,
+            }
+        )
+        return base_url + "/" + size + "/" + hashURLpart + "/" + filename + "?" + params
+
+
+thumbr = ThumbrHelper()

--- a/tests/test_places.py
+++ b/tests/test_places.py
@@ -152,7 +152,7 @@ def test_full_query_tripadvisor():
             "contribute_url": "https://www.tripadvisor.com/Restaurant_Review-g1743691-d3166925-Reviews-Chez_Eric-Vaucluse_Provence_Alpes_Cote_d_Azur.html?m=66562",
             "maps_directions_url": "https://www.qwant.com/maps/routes/?destination=ta%3Apoi%3A3166925",
             "maps_place_url": "https://www.qwant.com/maps/place/ta:poi:3166925",
-            "rating_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-MCID-66562.svg",
+            "rating_url": "https://s2.qwant.com/thumbr/0x0/5/a/6b6f4892798122d02c825b74f0e59471d42868ffac0df83d9fdd09910ee664/4.5-MCID-66562.svg?u=https%3A%2F%2Fwww.tripadvisor.com%2Fimg%2Fcdsi%2Fimg2%2Fratings%2Ftraveler%2F4.5-MCID-66562.svg&q=0&b=1&p=0&a=0",
             "source": "tripadvisor",
             "source_url": "https://www.tripadvisor.com/Restaurant_Review-g1743691-d3166925-Reviews-Chez_Eric-Vaucluse_Provence_Alpes_Cote_d_Azur.html?m=66562",
         },


### PR DESCRIPTION
Rating image URLs currently expose the client to an external website, this PR wraps the images with the thumbr to keep the client's IP & cie safe.

See https://github.com/Qwant/erdapfel/pull/1278