### PR TITLE
image block: resize images images to fit what is displayed in erdapfel

### DIFF
--- a/idunn/blocks/images.py
+++ b/idunn/blocks/images.py
@@ -12,6 +12,10 @@ from .base import BaseBlock
 
 logger = logging.getLogger(__name__)
 
+# Resize images when using Thumbr, this is consistent with how the front
+# displays them in the pannel and bigger than needed for the list view
+IMAGES_HEIGHT = 165
+
 
 class Image(BaseModel):
     url: str
@@ -51,7 +55,7 @@ class ImagesBlock(BaseBlock):
     @classmethod
     def build_image(cls, raw_url, **kwargs):
         if thumbr.is_enabled():
-            thumb_url = thumbr.get_url_remote_thumbnail(raw_url)
+            thumb_url = thumbr.get_url_remote_thumbnail(raw_url, height=IMAGES_HEIGHT)
         else:
             thumb_url = raw_url
         return Image(url=thumb_url, **kwargs)

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -36,7 +36,7 @@ def test_wiki_image(orsay_wiki_es):
     assert resp["blocks"][4]["type"] == "images"
     assert resp["blocks"][4]["images"] == [
         {
-            "url": "https://s2.qwant.com/thumbr/0x0/3/9/43f34b2898978cd1c6cbfa90766ef432d761f02d31f32120eff6db12f616b5/1024px-Logo_musée_d'Orsay.png?u=https%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Ffr%2Fthumb%2F7%2F73%2FLogo_mus%25C3%25A9e_d%2527Orsay.png%2F1024px-Logo_mus%25C3%25A9e_d%2527Orsay.png&q=0&b=1&p=0&a=0",
+            "url": "https://s1.qwant.com/thumbr/0x165/e/a/cfd65707824a034b9b1d0429ec68590f13cf2d79ebda2ae65e5028a4f70cdd/1024px-Logo_musée_d'Orsay.png?u=https%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Ffr%2Fthumb%2F7%2F73%2FLogo_mus%25C3%25A9e_d%2527Orsay.png%2F1024px-Logo_mus%25C3%25A9e_d%2527Orsay.png&q=0&b=1&p=0&a=0",
             "alt": "Musée d'Orsay",
             "credits": "",
             "source_url": "https://upload.wikimedia.org/wikipedia/fr/thumb/7/73/Logo_mus%C3%A9e_d%27Orsay.png/1024px-Logo_mus%C3%A9e_d%27Orsay.png",

--- a/tests/test_places.py
+++ b/tests/test_places.py
@@ -128,7 +128,7 @@ def test_full_query_tripadvisor():
                         "alt": "",
                         "credits": "",
                         "source_url": "https://media-cdn.tripadvisor.com/media/photo-o/0f/e9/04/82/photo0jpg.jpg",
-                        "url": "https://s1.qwant.com/thumbr/0x0/2/9/7544620396926de281c446798aa58867a2be514c5bdc1f196280d2ea6556b0/photo0jpg.jpg?u=https%3A%2F%2Fmedia-cdn.tripadvisor.com%2Fmedia%2Fphoto-o%2F0f%2Fe9%2F04%2F82%2Fphoto0jpg.jpg&q=0&b=1&p=0&a=0",
+                        "url": "https://s2.qwant.com/thumbr/0x165/f/3/68116512232b4299814330da19513bb35915de590c814b17a3b598aee66c78/photo0jpg.jpg?u=https%3A%2F%2Fmedia-cdn.tripadvisor.com%2Fmedia%2Fphoto-o%2F0f%2Fe9%2F04%2F82%2Fphoto0jpg.jpg&q=0&b=1&p=0&a=0",
                     }
                 ],
                 "type": "images",


### PR DESCRIPTION
Some images can get pretty big, especially when displaying several of
them in the list view.

If we want more granularity it could make sense to specify that as a
parameter, but I don't think this would make any improvement in our
current use.