### PR TITLE
instant_answer: mix OSM and tripadvisor in direct query

### DIFF
--- a/idunn/api/instant_answer.py
+++ b/idunn/api/instant_answer.py
@@ -330,23 +330,19 @@ async def get_instant_answer(
     # without intention location detection
     else:
         if settings["TRIPADVISOR_ENABLED"]:
-            for bragi_tripadvisor_feature in bragi_tripadvisor_features:
-                feature_properties = bragi_tripadvisor_feature["properties"]["geocoding"]
-                source = feature_properties["id"].split(":")[0]
+            bragi_tripadvisor_feature = next(iter(bragi_tripadvisor_features), None)
 
-                if source != "ta" or (
-                    feature_properties["poi_types"][0]["id"].split(":")[0]
-                    in AVAILABLE_CLASS_TYPE_TRIPADVISOR
-                ):
-                    fetch_pj.cancel()
-                    fetch_bragi_osm.cancel()
-                    place_id = feature_properties["id"]
-                    return await run_in_threadpool(
-                        get_instant_answer_single_place,
-                        query=q,
-                        place_id=place_id,
-                        lang=lang,
-                    )
+            if bragi_tripadvisor_feature is not None:
+                fetch_pj.cancel()
+                fetch_bragi_osm.cancel()
+                feature_properties = bragi_tripadvisor_feature["properties"]["geocoding"]
+                place_id = feature_properties["id"]
+                return await run_in_threadpool(
+                    get_instant_answer_single_place,
+                    query=q,
+                    place_id=place_id,
+                    lang=lang,
+                )
 
     return await instant_answer_fallback(fetch_bragi_osm, lang, normalized_query, q, user_country)
 

--- a/idunn/api/instant_answer.py
+++ b/idunn/api/instant_answer.py
@@ -267,7 +267,7 @@ async def get_instant_answer(
     query = QueryParams.build(q=normalized_query, lang=lang, limit=5, **extra_geocoder_params)
     if settings["TRIPADVISOR_ENABLED"]:
         query_tripadvisor = deepcopy(query)
-        query_tripadvisor.poi_dataset.append("tripadvisor")
+        query_tripadvisor.poi_dataset += ["tripadvisor", "default"]
 
     async def fetch_pj_response():
         if not (settings["IA_CALL_PJ_POI"] and user_country == "fr" and intentions):
@@ -332,9 +332,10 @@ async def get_instant_answer(
         if settings["TRIPADVISOR_ENABLED"]:
             for bragi_tripadvisor_feature in bragi_tripadvisor_features:
                 feature_properties = bragi_tripadvisor_feature["properties"]["geocoding"]
-                if (
-                    "poi_types" in feature_properties
-                    and feature_properties["poi_types"][0]["id"].split(":")[0]
+                source = feature_properties["id"].split(":")[0]
+
+                if source != "ta" or (
+                    feature_properties["poi_types"][0]["id"].split(":")[0]
                     in AVAILABLE_CLASS_TYPE_TRIPADVISOR
                 ):
                     fetch_pj.cancel()
@@ -345,7 +346,6 @@ async def get_instant_answer(
                         query=q,
                         place_id=place_id,
                         lang=lang,
-                        type="poi_tripadvisor",
                     )
 
     return await instant_answer_fallback(fetch_bragi_osm, lang, normalized_query, q, user_country)


### PR DESCRIPTION
As weights for TA POIs are rather high, they are already prioritized
compared to OSM POIs and this won't be too agressive by hiding potential
much more relevent OSM documents.