### PR TITLE
instant_answer: fix exception for unsupported nlu langs

### DIFF
--- a/idunn/api/instant_answer.py
+++ b/idunn/api/instant_answer.py
@@ -241,7 +241,7 @@ async def get_instant_answer(
             return build_response(result, query=q, lang=lang)
         return no_instant_answer(query=q, lang=lang, region=user_country)
 
-    intentions = None
+    intentions = []
     if lang in nlu_allowed_languages:
         try:
             intentions = await nlu_client.get_intentions(
@@ -290,7 +290,7 @@ async def get_instant_answer(
 
     # Select datasource instant answer in France
     if (
-        len(intentions) > 0
+        intentions
         and intentions[0].filter is not None
         and intentions[0].filter.bbox is not None
         and pj_source.bbox_is_covered(intentions[0].filter.bbox)


### PR DESCRIPTION
The `intentions` variable was set to `None` by default and never overridden for unsupported languages. This led to an exception when checking for `len(intentions)`.

I actually double fixed the issue:
 - setting intentions to None makes the "type" of the variable to `Optional[List[..]]` where it can be just a list
 - just checking `if intentions` is more idiomatic python than `if len(intentions) > 0`