### PR TITLE
urlsolver: do not raise an exception for 4xx/5xx and fix errors for 3xx

### DIFF
--- a/idunn/api/urlsolver.py
+++ b/idunn/api/urlsolver.py
@@ -40,9 +40,8 @@ async def follow_redirection(
         raise HTTPException(403, detail="provided hash does not match the URL")
 
     response = await client.get(url, follow_redirects=False)
-    response.raise_for_status()
 
     if response.status_code not in range(300, 400):
-        raise HTTPException(404, detail="provided URL does not redirect")
+        raise HTTPException(404, detail=f"`{url}` does not redirect, got {response.status_code}")
 
     return RedirectResponse(response.headers["Location"])


### PR DESCRIPTION
httpx seems to have changed its behavior, and it doesn't really make
sense to raise an exception in Idunn when provided with an invalid URL
anyway.