### PR TITLE
rate_limiter: use a single connection pool

### DIFF
--- a/idunn/api/directions.py
+++ b/idunn/api/directions.py
@@ -4,15 +4,8 @@ from pydantic import confloat
 from idunn import settings
 from idunn.places import Latlon
 from idunn.places.exceptions import IdunnPlaceError
-from idunn.utils.rate_limiter import IdunnRateLimiter
 from ..directions.client import directions_client
 from ..utils.place import place_from_id
-
-rate_limiter = IdunnRateLimiter(
-    resource="idunn.api.directions",
-    max_requests=int(settings["DIRECTIONS_RL_MAX_REQUESTS"]),
-    expire=int(settings["DIRECTIONS_RL_EXPIRE"]),
-)
 
 
 def directions_request(request: Request, response: Response):
@@ -20,7 +13,6 @@ def directions_request(request: Request, response: Response):
     FastAPI Dependency
     Responsible for rate limit and cache headers for directions requests
     """
-    rate_limiter.check_limit_per_client(request)
     response.headers["cache-control"] = f"max-age={settings['DIRECTIONS_CLIENT_CACHE']}"
     return request
 

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -59,7 +59,7 @@ LIST_PLACES_RL_MAX_REQUESTS: 100 # req per client
 LIST_PLACES_RL_EXPIRE: 900 # seconds
 
 ## Place detail
-GET_PLACE_RL_MAX_REQUESTS: 30 # req per client
+GET_PLACE_RL_MAX_REQUESTS: 60 # req per client
 GET_PLACE_RL_EXPIRE: 60 # seconds
 
 ########################

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -58,6 +58,10 @@ LIST_PLACES_EXTENDED_BBOX_MAX_SIZE: "0.4" # Lat/lon degrees
 LIST_PLACES_RL_MAX_REQUESTS: 100 # req per client
 LIST_PLACES_RL_EXPIRE: 900 # seconds
 
+## Place detail
+GET_PLACE_RL_MAX_REQUESTS: 30 # req per client
+GET_PLACE_RL_EXPIRE: 60 # seconds
+
 ########################
 ## Redis
 REDIS_URL:

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -58,7 +58,7 @@ LIST_PLACES_EXTENDED_BBOX_MAX_SIZE: "0.4" # Lat/lon degrees
 LIST_PLACES_RL_MAX_REQUESTS: 100 # req per client
 LIST_PLACES_RL_EXPIRE: 900 # seconds
 
-## Place detail
+## Get place detail
 GET_PLACE_RL_MAX_REQUESTS: 60 # req per client
 GET_PLACE_RL_EXPIRE: 60 # seconds
 

--- a/idunn/utils/default_test_settings.yaml
+++ b/idunn/utils/default_test_settings.yaml
@@ -59,7 +59,7 @@ LIST_PLACES_RL_MAX_REQUESTS: 100 # req per client
 LIST_PLACES_RL_EXPIRE: 900 # seconds
 
 ## Place detail
-GET_PLACE_RL_MAX_REQUESTS: 30 # req per client
+GET_PLACE_RL_MAX_REQUESTS: 60 # req per client
 GET_PLACE_RL_EXPIRE: 60 # seconds
 
 ########################

--- a/idunn/utils/default_test_settings.yaml
+++ b/idunn/utils/default_test_settings.yaml
@@ -58,6 +58,10 @@ LIST_PLACES_EXTENDED_BBOX_MAX_SIZE: "0.4" # Lat/lon degrees
 LIST_PLACES_RL_MAX_REQUESTS: 100 # req per client
 LIST_PLACES_RL_EXPIRE: 900 # seconds
 
+## Place detail
+GET_PLACE_RL_MAX_REQUESTS: 30 # req per client
+GET_PLACE_RL_EXPIRE: 60 # seconds
+
 ########################
 ## Redis
 REDIS_URL:

--- a/idunn/utils/default_test_settings.yaml
+++ b/idunn/utils/default_test_settings.yaml
@@ -58,7 +58,7 @@ LIST_PLACES_EXTENDED_BBOX_MAX_SIZE: "0.4" # Lat/lon degrees
 LIST_PLACES_RL_MAX_REQUESTS: 100 # req per client
 LIST_PLACES_RL_EXPIRE: 900 # seconds
 
-## Place detail
+## Get place detail
 GET_PLACE_RL_MAX_REQUESTS: 60 # req per client
 GET_PLACE_RL_EXPIRE: 60 # seconds
 

--- a/idunn/utils/redis.py
+++ b/idunn/utils/redis.py
@@ -27,7 +27,6 @@ def get_redis_pool(db):
 
     if not redis_url.startswith("redis://"):
         redis_url = "redis://" + redis_url
-
     return ConnectionPool.from_url(url=redis_url, socket_timeout=REDIS_TIMEOUT, db=db)
 
 

--- a/tests/test_directions.py
+++ b/tests/test_directions.py
@@ -3,15 +3,14 @@ import json
 import responses
 import re
 import pytest
+from app import app
+from fastapi.testclient import TestClient
+from freezegun import freeze_time
 from idunn import settings
 from idunn.utils import rate_limiter
-from fastapi.testclient import TestClient
-from app import app
-from freezegun import freeze_time
 from idunn.utils.redis import get_redis_pool
 
-from tests.test_rate_limiter import disable_redis, limiter_test_normal
-
+from .test_rate_limiter import disable_redis, limiter_test_normal
 from .utils import override_settings
 
 


### PR DESCRIPTION
This should help hitting less heavily on the Redis connection pool.

I've also taken this chance to add a rate limit on the place endpoint, as it can easily expose an external API.