### PR TITLE
rate limiter disabled for requests with no client hash

### DIFF
--- a/idunn/utils/rate_limiter.py
+++ b/idunn/utils/rate_limiter.py
@@ -70,7 +70,12 @@ class IdunnRateLimiter:
         return limit()
 
     def check_limit_per_client(self, request):
-        client_id = request.headers.get("x-client-hash") or "default"
+        client_id = request.headers.get("x-client-hash")
+
+        if client_id is None:
+            logger.warning("Ignoring rate limiting for request with no hash")
+            return
+
         try:
             with self.limit(client=client_id, ignore_redis_error=True):
                 pass

--- a/tests/test_directions.py
+++ b/tests/test_directions.py
@@ -218,5 +218,6 @@ def test_directions_rate_limiter(limiter_test_normal, mock_directions_car_with_r
         response = client.get(
             "http://localhost/v1/directions/" "2.3402355%2C48.8900732%3B2.3688579%2C48.8529869",
             params={"language": "fr", "type": "driving"},
+            headers={"x-client-hash": "test-client-hash-value"},
         )
     assert response.status_code == 429


### PR DESCRIPTION
As we have no way to determine were the requests with no hash comes from,
there is not really any reason to perform the rate limiting for them:

 - if it comes from another internal component (eg. Erdapfel), it feels
   reasonable to just display a warning as said component should forward
   the header.

 - if the HA proxy fails to set the header value, it also feels better
   to just display a warning instead of penalizing the client for the
   overall traffic bandwidth.

 - the only other scenario I can think of is some kind of internal stress
   test, which we are currently performing, in which case it is more
   convenient if the rate limiter is disabled.