### PR TITLE
Add only osm source

### DIFF
--- a/idunn/api/places_list.py
+++ b/idunn/api/places_list.py
@@ -68,6 +68,7 @@ class PlacesQueryParam(CommonQueryParam):
     source: Optional[str]
     q: Optional[str]
     extend_bbox: bool = False
+    only_osm: bool = False
 
     def __init__(self, **data: Any):
         try:
@@ -152,6 +153,7 @@ async def get_places_bbox(
     lang: Optional[str] = Query(None),
     verbosity: Verbosity = Verbosity.default_list(),
     extend_bbox: bool = Query(False),
+    only_osm: bool = Query(False),
 ) -> PlacesBboxResponse:
     """Get all places in a bounding box."""
     params = PlacesQueryParam(**locals())
@@ -205,12 +207,16 @@ def select_datasource_for_france(params):
         params.source = PoiSource.PAGESJAUNES
     else:
         params.source = PoiSource.OSM
+    if params.only_osm:
+        params.source = PoiSource.OSM
 
 
 def select_datasource_outside_france(params):
     if any(cat in params.category for cat in TRIPADVISOR_CATEGORIES_COVERED_WORLDWIDE):
         params.source = PoiSource.TRIPADVISOR
     else:
+        params.source = PoiSource.OSM
+    if params.only_osm:
         params.source = PoiSource.OSM
 
 


### PR DESCRIPTION
If "qmaps_v1_only_osm" value exist in the localstorage, add a parameter in the url to get only osm results for category and intention
Resolve : https://github.com/Qwant/qwantmaps/issues/176 
According to https://github.com/Qwant/erdapfel/pull/1343