### PR TITLE
app: makes app path prefix configurable with URL_PATH_PREFIX

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 
 # Setup docs settings
 base_url = settings["BASE_URL"]
+path_prefix = settings["URL_PATH_PREFIX"]
 root_path = urlparse(base_url).path.rstrip("/")
 docs_settings = {}
 if not settings["DOCS_ENABLED"]:
@@ -20,7 +21,7 @@ app = FastAPI(
     title="Idunn", version="0.2", debug=__name__ == "__main__", root_path=root_path, **docs_settings
 )
 v1_routes = get_api_urls(settings)
-app.include_router(APIRouter(routes=v1_routes), prefix="/v1")
+app.include_router(APIRouter(routes=v1_routes), prefix=path_prefix)
 
 # Configure CORS
 app.add_middleware(

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -2,6 +2,7 @@ USER_AGENT: "Idunn/0.1"
 
 BASE_URL: http://localhost:5000/ # Base URL of Idunn's endpoint
 MAPS_BASE_URL: https://www.qwant.com/maps/
+URL_PATH_PREFIX: "/v1" # URL prefix the HTTP client listens to
 
 SECRET: "CHANGE_ME"
 


### PR DESCRIPTION
The app's URL prefix is currently hardcoded to `/v1`. Making this configurable would allow us to not have to use an nginx with the only purpose of rewriting `/maps/detail/v1` URLs into `/v1`.