### PR TITLE
Generic ia for all maps request beginning with Mappy

### DIFF
--- a/idunn/instant_answer/patterns_to_ignore.txt
+++ b/idunn/instant_answer/patterns_to_ignore.txt
@@ -24,3 +24,4 @@ localisation
 o(ù|u) (se|ce) (trouve|situe)( (le|la))?
 where is
 booking$
+mappy .*

--- a/idunn/instant_answer/patterns_to_ignore.txt
+++ b/idunn/instant_answer/patterns_to_ignore.txt
@@ -18,10 +18,12 @@ quartier de
 ville de
 code postale?
 (google )?street ?view
-itin(e|é)raires?
 lieu dit
 localisation
 o(ù|u) (se|ce) (trouve|situe)( (le|la))?
 where is
 booking$
+mappy (plan|itin(e|é)rair(e|es))
+itin(e|é)rair(e|es) mappy
+itin(e|é)rair(e|es)?
 mappy

--- a/idunn/instant_answer/patterns_to_ignore.txt
+++ b/idunn/instant_answer/patterns_to_ignore.txt
@@ -24,4 +24,4 @@ localisation
 o(ù|u) (se|ce) (trouve|situe)( (le|la))?
 where is
 booking$
-mappy .*
+mappy


### PR DESCRIPTION
Remove query with the following pattern to display a generic IA :  Mappy / Mappy plan / Mappy itinéraire  / itinéraire Mappy